### PR TITLE
Tasks instances issue

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -85,7 +85,7 @@ public class DeciderService {
         this.externalPayloadStorageUtils = externalPayloadStorageUtils;
         this.taskPendingTimeThresholdMins = taskPendingTimeThreshold.toMinutes();
         this.systemTaskRegistry = systemTaskRegistry;
-        this.wfInstanceCache = Utils.getCaffeineCache(24, TimeUnit.HOURS);
+        this.wfInstanceCache = Utils.getCaffeineCache(6, TimeUnit.HOURS);
     }
 
     public DeciderOutcome decide(WorkflowModel workflow) throws TerminateWorkflowException {
@@ -841,18 +841,20 @@ public class DeciderService {
                 parametersUtils.getTaskInput(
                         taskToSchedule.getInputParameters(), workflow, null, null);
 
-        LOGGER.info("DeciderService getTasksToBeScheduled workflowTasks {}",
+        LOGGER.info("DeciderService getTasksToBeScheduled workflowTasks {} for workflow_id {} ",
                 workflow.getTasks().stream().map(TaskModel::getReferenceTaskName)
-                .toList());
-        LOGGER.info("DeciderService getTasksToBeScheduled cached wfInstanceCache {} ",
-                wfInstanceCache.getIfPresent(workflow.getWorkflowId()));
+                .toList(), workflow.getWorkflowId());
+        LOGGER.info("DeciderService getTasksToBeScheduled cached wfInstanceCache {} for workflow_id {} ",
+                wfInstanceCache.getIfPresent(workflow.getWorkflowId()), workflow.getWorkflowId());
 
         if (wfInstanceCache.getIfPresent(workflow.getWorkflowId()) != null) {
             tasksInWorkflowCached.addAll(wfInstanceCache.getIfPresent(workflow.getWorkflowId()));
         }
 
-        LOGGER.info("Added tasks to tasksInWorkflowCached {} ", tasksInWorkflowCached);
-        LOGGER.info("DeciderService getTasksToBeScheduled taskToSchedule {}", taskToSchedule.getTaskReferenceName());
+        LOGGER.info("Added tasks to tasksInWorkflowCached {} for workflow_id {}",
+                tasksInWorkflowCached, workflow.getWorkflowId());
+        LOGGER.info("DeciderService getTasksToBeScheduled taskToSchedule {}, for workflow_id {}",
+                taskToSchedule.getTaskReferenceName(), workflow.getWorkflowId());
 
 
         String taskId = idGenerator.generate();

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1445,7 +1445,8 @@ public class WorkflowExecutor {
         List<TaskModel> tasksToBeQueued;
         boolean startedSystemTasks = false;
 
-        LOGGER.info("WorkflowExecutor received tasks for scheduleTask {}", tasks.stream().map(TaskModel::getReferenceTaskName).toList());
+        LOGGER.info("WorkflowExecutor received tasks for scheduleTask {} for workflow_id {}",
+                tasks.stream().map(TaskModel::getReferenceTaskName).toList(),workflow.getWorkflowId());
 
         try {
             if (tasks == null || tasks.isEmpty()) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1054,7 +1054,9 @@ public class WorkflowExecutor {
 
             List<TaskModel> tasksToBeScheduled = outcome.tasksToBeScheduled;
             setTaskDomains(tasksToBeScheduled, workflow);
+            LOGGER.info("WorkflowExecutor decide tasksToBeScheduled {}", tasksToBeScheduled.stream().map(TaskModel::getReferenceTaskName).toList());
             List<TaskModel> tasksToBeUpdated = outcome.tasksToBeUpdated;
+            LOGGER.info("WorkflowExecutor decide tasksToBeUpdated {}", tasksToBeUpdated.stream().map(TaskModel::getReferenceTaskName).toList());
 
             tasksToBeScheduled = dedupAndAddTasks(workflow, tasksToBeScheduled);
 
@@ -1359,8 +1361,8 @@ public class WorkflowExecutor {
             queueDAO.push(taskQueueName, task.getTaskId(), task.getWorkflowPriority(), 0);
         }
         LOGGER.debug(
-                "Added task {} with priority {} to queue {} with call back seconds {}",
-                task,
+                "Added taskRefName {} with priority {} to queue {} with call back seconds {}",
+                task.getReferenceTaskName(),
                 task.getWorkflowPriority(),
                 taskQueueName,
                 task.getCallbackAfterSeconds());
@@ -1442,6 +1444,8 @@ public class WorkflowExecutor {
     boolean scheduleTask(WorkflowModel workflow, List<TaskModel> tasks) {
         List<TaskModel> tasksToBeQueued;
         boolean startedSystemTasks = false;
+
+        LOGGER.info("WorkflowExecutor received tasks for scheduleTask {}", tasks.stream().map(TaskModel::getReferenceTaskName).toList());
 
         try {
             if (tasks == null || tasks.isEmpty()) {

--- a/core/src/main/java/com/netflix/conductor/core/listener/WorkflowStatusListener.java
+++ b/core/src/main/java/com/netflix/conductor/core/listener/WorkflowStatusListener.java
@@ -18,9 +18,7 @@ import com.netflix.conductor.model.WorkflowModel;
 public interface WorkflowStatusListener {
 
     default void onWorkflowCompletedIfEnabled(WorkflowModel workflow) {
-        if (workflow.getWorkflowDefinition().isWorkflowStatusListenerEnabled()) {
             onWorkflowCompleted(workflow);
-        }
     }
 
     default void onWorkflowTerminatedIfEnabled(WorkflowModel workflow) {

--- a/core/src/main/java/com/netflix/conductor/core/utils/Utils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/Utils.java
@@ -15,7 +15,10 @@ package com.netflix.conductor.core.utils;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.commons.lang3.StringUtils;
 
 import com.netflix.conductor.core.exception.TransientException;
@@ -90,5 +93,15 @@ public class Utils {
             return throwable instanceof TransientException;
         }
         return true;
+    }
+
+    /**
+     * Get a new instance of Caffeine cache with the specified expiration and time unit.
+     * @param expiration
+     * @param timeUnit
+     * @return
+     */
+    public static Cache<String, Set<String>> getCaffeineCache(Integer expiration, TimeUnit timeUnit) {
+        return Caffeine.newBuilder().expireAfterWrite(expiration, timeUnit).build();
     }
 }

--- a/docker/server/config/config-conductor-server.properties
+++ b/docker/server/config/config-conductor-server.properties
@@ -24,7 +24,8 @@ conductor.scylla.cluster=scylla_cluster
 conductor.scylla.keyspace=${SCYLLA_KEYSPACE}
 conductor.scylla.replicationFactorValue=${SCYLLA_REPLICATIONFACTOR}
 
-conductor.workflow-status-listener.type=archive
+#conductor.workflow-status-listener.type=archive
+conductor.workflow-status-listener.enabled=false
 
 conductor.system-task-workers.enabled=true
 

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
@@ -238,13 +238,15 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         try {
             WorkflowMetadata workflowMetadata = getWorkflowMetadata(workflowId,corelationId);
             int totalTasks = workflowMetadata.getTotalTasks() + tasks.size();
-            // update the task_lookup table
-            // update the workflow_lookup table
+            LOGGER.info("createTasks  taskList size {} for given workflow instanceId {},totalTasks {} and tasks :: {} ",
+                    tasks.size(),workflowUUID, totalTasks ,tasks);
             tasks.forEach(
                     task -> {
                         if (task.getScheduledTime() == 0) {
                             task.setScheduledTime(System.currentTimeMillis());
                         }
+                        // update the task_lookup table
+                        // update the workflow_lookup table
                         session.execute(
                                 updateTaskLookupStatement.bind(
                                         workflowUUID, correlationId, toUUID(task.getTaskId(), "Invalid task id")));
@@ -542,12 +544,29 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
             recordCassandraDaoRequests("updateWorkflow", "n/a", workflow.getWorkflowName());
             recordCassandraDaoPayloadSize(
                     "updateWorkflow", payload.length(), "n/a", workflow.getWorkflowName());
-            session.execute(
-                    updateWorkflowStatement.bind(
-                            payload, UUID.fromString(workflow.getWorkflowId()),correlationId));
+            WorkflowModel prevWorkflow = getWorkflow(workflow.getWorkflowId(), false);
+            LOGGER.debug(
+                    "prevWorkflow status updated for workflow_id {} is {}",
+                    prevWorkflow.getWorkflowId(),
+                    prevWorkflow.getStatus());
+            // Added this change to update the workflow only if it is not completed, Rerun cannot be done on completed workflows
+            if (!prevWorkflow.getStatus().equals(WorkflowModel.Status.COMPLETED)) {
+                session.execute(
+                        updateWorkflowStatement.bind(
+                                payload, UUID.fromString(workflow.getWorkflowId()), correlationId));
+            } else {
+                LOGGER.info(
+                        "Workflow {} is already completed. Not updating the workflow current status {}",
+                        workflow.getWorkflowId(), workflow.getStatus());
+                return workflow.getWorkflowId();
+            }
+            LOGGER.debug(
+                    "Workflow status updated for workflow_id {} is {}",
+                    workflow.getWorkflowId(),
+                    workflow.getStatus());
             workflow.setTasks(tasks);
             return workflow.getWorkflowId();
-        } catch (DriverException e) {
+        } catch (Exception e) {
             Monitors.error(CLASS_NAME, "updateWorkflow");
             String errorMsg =
                     String.format("Failed to update workflow: %s", workflow.getWorkflowId());

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
@@ -551,16 +551,21 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
                     prevWorkflow.getStatus());
             // Added this change to update the workflow only if it is not completed, Rerun cannot be done on completed workflows
             if (!prevWorkflow.getStatus().equals(WorkflowModel.Status.COMPLETED)) {
-                session.execute(
-                        updateWorkflowStatement.bind(
-                                payload, UUID.fromString(workflow.getWorkflowId()), correlationId));
+                LOGGER.info(
+                        "Previous Completed workflow  :: {} and still current workflow status :: {} for workflow_id - {}",
+                        prevWorkflow.getStatus(),
+                        workflow.getStatus(),
+                        prevWorkflow.getWorkflowId());
             } else {
                 LOGGER.info(
-                        "Workflow {} is already completed. Not updating the workflow current status {}",
+                        "Workflow {} is already completed. ",
                         workflow.getWorkflowId(), workflow.getStatus());
                 return workflow.getWorkflowId();
             }
-            LOGGER.debug(
+            session.execute(
+                    updateWorkflowStatement.bind(
+                            payload, UUID.fromString(workflow.getWorkflowId()), correlationId));
+            LOGGER.info(
                     "Workflow status updated for workflow_id {} is {}",
                     workflow.getWorkflowId(),
                     workflow.getStatus());

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -126,3 +126,5 @@ conductor.workflow-execution-lock.type=noop_lock
 # Additional modules for metrics collection exposed to Datadog (optional)
 management.metrics.export.datadog.enabled=${conductor.metrics-datadog.enabled:false}
 management.metrics.export.datadog.api-key=${conductor.metrics-datadog.api-key:}
+
+logging.level.root=DEBUG


### PR DESCRIPTION
This PR is excerpted from staging debug to rollout only  multiple task instances issue and workflow status getting in running -

1- Introduced Caffeine cache for managing the tasks instances during multiple thread run sync and enabled AtomicReference for workflow executed tasks.
2- Added a manual check for avoiding the workflow status update when a workflow is marked COMPLETED to avoid making thread race marking it RUNNING again. 
3- Removed check for workflow archival if already marked completed. We can enable as and when wanted based on configuration flag- For now its disabled from configuration.