### PR TITLE
[FS-222899] Conductor Workflow Execution failed due to Integer limit breach for correlation id

### DIFF
--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraExecutionDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraExecutionDAO.java
@@ -234,7 +234,7 @@ public class CassandraExecutionDAO extends CassandraBaseDAO
         String workflowId = tasks.get(0).getWorkflowInstanceId();
         String corelationId = tasks.get(0).getCorrelationId();
         UUID workflowUUID = toUUID(workflowId, "Invalid workflow id");
-        Integer correlationId = Objects.isNull(corelationId) ? 0 : Integer.parseInt(corelationId);
+        Long correlationId = Objects.isNull(corelationId) ? 0L : Long.parseLong(corelationId);
         try {
             WorkflowMetadata workflowMetadata = getWorkflowMetadata(workflowId,corelationId);
             int totalTasks = workflowMetadata.getTotalTasks() + tasks.size();
@@ -338,7 +338,7 @@ public class CassandraExecutionDAO extends CassandraBaseDAO
     @Override
     public void updateTask(TaskModel task) {
         try {
-            Integer correlationId = Objects.isNull(task.getCorrelationId()) ? 0 : Integer.parseInt(task.getCorrelationId());
+            Long correlationId = Objects.isNull(task.getCorrelationId()) ? 0L : Long.parseLong(task.getCorrelationId());
             String taskPayload = toJson(task);
             recordCassandraDaoRequests("updateTask", task.getTaskType(), task.getWorkflowType());
             recordCassandraDaoPayloadSize(
@@ -442,7 +442,7 @@ public class CassandraExecutionDAO extends CassandraBaseDAO
         try {
             String workflowId = lookupWorkflowIdFromTaskId(taskId);
             String shardId = lookupShardIdFromTaskId(taskId);
-            Integer correlationId = Objects.isNull(shardId) ? 0 : Integer.parseInt(shardId);
+            Long correlationId = Objects.isNull(shardId) ? 0L : Long.parseLong(shardId);
             if (workflowId == null) {
                 return null;
             }
@@ -509,7 +509,7 @@ public class CassandraExecutionDAO extends CassandraBaseDAO
             List<TaskModel> tasks = workflow.getTasks();
             workflow.setTasks(new LinkedList<>());
             String payload = toJson(workflow);
-            Integer correlationId = Objects.isNull(workflow.getCorrelationId()) ? 0 : Integer.parseInt(workflow.getCorrelationId());
+            Long correlationId = Objects.isNull(workflow.getCorrelationId()) ? 0L : Long.parseLong(workflow.getCorrelationId());
             LOGGER.info(
                     "Correlation ID for workflow {} is {}",
                     workflow.getWorkflowId(),
@@ -536,7 +536,7 @@ public class CassandraExecutionDAO extends CassandraBaseDAO
     public String updateWorkflow(WorkflowModel workflow) {
         try {
             List<TaskModel> tasks = workflow.getTasks();
-            Integer correlationId = Objects.isNull(workflow.getCorrelationId()) ? 0 : Integer.parseInt(workflow.getCorrelationId());
+            Long correlationId = Objects.isNull(workflow.getCorrelationId()) ? 0L : Long.parseLong(workflow.getCorrelationId());
             workflow.setTasks(new LinkedList<>());
             String payload = toJson(workflow);
             recordCassandraDaoRequests("updateWorkflow", "n/a", workflow.getWorkflowName());
@@ -559,7 +559,7 @@ public class CassandraExecutionDAO extends CassandraBaseDAO
     @Override
     public boolean removeWorkflow(String workflowId) {
         WorkflowModel workflow = getWorkflow(workflowId, true);
-        Integer correlationId = Objects.isNull(workflow.getCorrelationId()) ? 0 : Integer.parseInt(workflow.getCorrelationId());
+        Long correlationId = Objects.isNull(workflow.getCorrelationId()) ? 0L : Long.parseLong(workflow.getCorrelationId());
         boolean removed = false;
         if (workflow != null) {
             try {
@@ -609,7 +609,7 @@ public class CassandraExecutionDAO extends CassandraBaseDAO
     public WorkflowModel getWorkflow(String workflowId, boolean includeTasks) {
         UUID workflowUUID = toUUID(workflowId, "Invalid workflow id");
         String shardId = lookupShardIdFromWorkflowId(workflowId);
-        Integer correlationId = Objects.isNull(shardId) ? 0 : Integer.parseInt(shardId);
+        Long correlationId = Objects.isNull(shardId) ? 0L : Long.parseLong(shardId);
 
         try {
             WorkflowModel workflow = null;
@@ -903,7 +903,7 @@ public class CassandraExecutionDAO extends CassandraBaseDAO
             // get total tasks for this workflow
             WorkflowMetadata workflowMetadata = getWorkflowMetadata(task.getWorkflowInstanceId(),
                     task.getCorrelationId());
-            Integer correlationId = Objects.isNull(task.getCorrelationId()) ? 0 : Integer.parseInt(task.getCorrelationId());
+            Long correlationId = Objects.isNull(task.getCorrelationId()) ? 0L : Long.parseLong(task.getCorrelationId());
             int totalTasks = workflowMetadata.getTotalTasks();
 
             // remove from task_lookup table
@@ -984,7 +984,7 @@ public class CassandraExecutionDAO extends CassandraBaseDAO
 
     @VisibleForTesting
     WorkflowMetadata getWorkflowMetadata(String workflowId, String correlationId) {
-        Integer corelId = Objects.isNull(correlationId) ? 0 : Integer.parseInt(correlationId);
+        Long corelId = Objects.isNull(correlationId) ? 0L : Long.parseLong(correlationId);
         ResultSet resultSet =
                 session.execute(selectTotalStatement.bind(UUID.fromString(workflowId),corelId));
         recordCassandraDaoRequests("getWorkflowMetadata");

--- a/cassandra-persistence/src/test/groovy/com/netflix/conductor/cassandra/dao/CassandraExecutionDAOSpec.groovy
+++ b/cassandra-persistence/src/test/groovy/com/netflix/conductor/cassandra/dao/CassandraExecutionDAOSpec.groovy
@@ -31,6 +31,8 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
     @Subject
     CassandraExecutionDAO executionDAO
 
+    private String correlationId = "2180000016"
+
     def setup() {
         executionDAO = new CassandraExecutionDAO(session, objectMapper, cassandraProperties, statements)
     }
@@ -40,8 +42,8 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
         def tasks = []
 
         // create tasks for a workflow and add to list
-        TaskModel task1 = new TaskModel(workflowInstanceId: 'uuid', taskId: 'task1id', referenceTaskName: 'task1')
-        TaskModel task2 = new TaskModel(workflowInstanceId: 'uuid', taskId: 'task2id', referenceTaskName: 'task2')
+        TaskModel task1 = new TaskModel(workflowInstanceId: 'uuid', taskId: 'task1id', referenceTaskName: 'task1', correlationId: correlationId)
+        TaskModel task2 = new TaskModel(workflowInstanceId: 'uuid', taskId: 'task2id', referenceTaskName: 'task2', correlationId: correlationId)
         tasks << task1 << task2
 
         when:
@@ -72,6 +74,7 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
         WorkflowModel workflow = new WorkflowModel()
         workflow.setWorkflowDefinition(workflowDef)
         workflow.setWorkflowId(workflowId)
+        workflow.setCorrelationId(correlationId)
         workflow.setInput(new HashMap<>())
         workflow.setStatus(WorkflowModel.Status.RUNNING)
         workflow.setCreateTime(System.currentTimeMillis())
@@ -120,13 +123,13 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
         given: 'we create a workflow'
         String workflowId = new IDGenerator().generate()
         WorkflowDef workflowDef = new WorkflowDef(name: 'def1', version: 1)
-        WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, input: new HashMap(), status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis())
+        WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, input: new HashMap(), status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis(), correlationId: correlationId)
         executionDAO.createWorkflow(workflow)
 
         and: 'create tasks for this workflow'
-        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
-        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
-        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
+        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
+        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
+        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
 
         def taskList = [task1, task2, task3]
 
@@ -193,13 +196,13 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
         given: 'we create a workflow'
         String workflowId = new IDGenerator().generate()
         WorkflowDef workflowDef = new WorkflowDef(name: 'def1', version: 1)
-        WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, input: new HashMap(), status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis())
+        WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, input: new HashMap(), status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis(), correlationId: correlationId)
         executionDAO.createWorkflow(workflow)
 
         and: 'create tasks for this workflow'
-        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
-        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
-        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
+        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
+        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
+        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
 
         and: 'add the tasks to the datastore'
         executionDAO.createTasks([task1, task2, task3])
@@ -231,13 +234,13 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
         given: 'we create a workflow'
         String workflowId = new IDGenerator().generate()
         WorkflowDef workflowDef = new WorkflowDef(name: 'def1', version: 1)
-        WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, input: new HashMap(), status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis())
+        WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, input: new HashMap(), status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis(), correlationId: correlationId)
         executionDAO.createWorkflow(workflow)
 
         and: 'create tasks for this workflow'
-        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
-        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
-        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
+        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
+        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
+        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
 
         and: 'add the tasks to the datastore'
         executionDAO.createTasks([task1, task2, task3])
@@ -302,6 +305,7 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
         newTask.setTaskType("test_task")
         newTask.setWorkflowType("test_workflow")
         newTask.setStatus(TaskModel.Status.SCHEDULED)
+        newTask.setCorrelationId(correlationId)
 
         when: // no tasks are IN_PROGRESS
         executionDAO.addTaskToLimit(task)
@@ -409,7 +413,7 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
         String workflowId = new IDGenerator().generate()
         WorkflowTask workflowTask = new WorkflowTask(taskDefinition: new TaskDef(concurrentExecLimit: 2))
         WorkflowDef workflowDef = new WorkflowDef(name: UUID.randomUUID().toString(), version: 1, tasks: [workflowTask])
-        WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis())
+        WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis(), correlationId: correlationId)
 
         when: 'serialize workflow'
         def workflowJson = objectMapper.writeValueAsString(workflow)
@@ -429,7 +433,7 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
         given: 'define a workflow and tasks for this workflow'
         String workflowId = new IDGenerator().generate()
         WorkflowTask workflowTask = new WorkflowTask(taskDefinition: new TaskDef(concurrentExecLimit: 2))
-        TaskModel task = new TaskModel(workflowInstanceId: workflowId, taskType: UUID.randomUUID().toString(), referenceTaskName: UUID.randomUUID().toString(), status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), workflowTask: workflowTask)
+        TaskModel task = new TaskModel(workflowInstanceId: workflowId, taskType: UUID.randomUUID().toString(), referenceTaskName: UUID.randomUUID().toString(), status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), workflowTask: workflowTask, correlationId: correlationId)
 
         when: 'serialize task'
         def taskJson = objectMapper.writeValueAsString(task)
@@ -451,7 +455,7 @@ class CassandraExecutionDAOSpec extends CassandraSpec {
         WorkflowDef workflowDef = new WorkflowDef(name: UUID.randomUUID().toString(), version: 1, tasks: workflowTasks)
 
         def taskList = (0..999)
-                .collect { new TaskModel(workflowInstanceId: workflowId, taskType: it, referenceTaskName: it, status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), workflowTask: workflowTasks.get(it)) }
+                .collect { new TaskModel(workflowInstanceId: workflowId, taskType: it, referenceTaskName: it, status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), workflowTask: workflowTasks.get(it), correlationId: correlationId) }
 
         WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis())
 

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
@@ -241,7 +241,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         String workflowId = tasks.get(0).getWorkflowInstanceId();
         String corelationId = tasks.get(0).getCorrelationId();
         UUID workflowUUID = toUUID(workflowId, "Invalid workflow id");
-        Integer correlationId = Objects.isNull(corelationId) ? 0 : Integer.parseInt(corelationId);
+        Long correlationId = Objects.isNull(corelationId) ? 0L : Long.parseLong(corelationId);
         try {
             WorkflowMetadata workflowMetadata = getWorkflowMetadata(workflowId,corelationId);
             int totalTasks = workflowMetadata.getTotalTasks() + tasks.size();
@@ -347,7 +347,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     @Override
     public void updateTask(TaskModel task) {
         try {
-            Integer correlationId = Objects.isNull(task.getCorrelationId()) ? 0 : Integer.parseInt(task.getCorrelationId());
+            Long correlationId = Objects.isNull(task.getCorrelationId()) ? 0L : Long.parseLong(task.getCorrelationId());
             String taskPayload = toJson(task);
             recordCassandraDaoRequests("updateTask", task.getTaskType(), task.getWorkflowType());
             recordCassandraDaoPayloadSize(
@@ -466,7 +466,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         try {
             String workflowId = lookupWorkflowIdFromTaskId(taskId);
             String shardId = lookupShardIdFromTaskId(taskId);
-            Integer correlationId = Objects.isNull(shardId) ? 0 : Integer.parseInt(shardId);
+            Long correlationId = Objects.isNull(shardId) ? 0L : Long.parseLong(shardId);
             if (workflowId == null) {
                 return null;
             }
@@ -560,7 +560,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     public String updateWorkflow(WorkflowModel workflow) {
         try {
             List<TaskModel> tasks = workflow.getTasks();
-            Integer correlationId = Objects.isNull(workflow.getCorrelationId()) ? 0 : Integer.parseInt(workflow.getCorrelationId());
+            Long correlationId = Objects.isNull(workflow.getCorrelationId()) ? 0L : Long.parseLong(workflow.getCorrelationId());
             workflow.setTasks(new LinkedList<>());
 
             WorkflowModel prevWorkflow = getWorkflow(workflow.getWorkflowId(), false);
@@ -585,7 +585,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         }
     }
 
-    private boolean attemptUpdateWorkflow(WorkflowModel workflow, WorkflowModel prevWorkflow,  String payload, Integer correlationId, Boolean isRetry) {
+    private boolean attemptUpdateWorkflow(WorkflowModel workflow, WorkflowModel prevWorkflow,  String payload, Long correlationId, Boolean isRetry) {
         Integer currentVersion = prevWorkflow.getVersion() == 0 ? null : prevWorkflow.getVersion();
         ResultSet resultSet = session.execute(updateWorkflowStatement.bind(payload, prevWorkflow.getVersion() + 1,
                 UUID.fromString(workflow.getWorkflowId()), correlationId, currentVersion));
@@ -598,7 +598,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     }
 
 
-    private void handleConcurrentUpdate(WorkflowModel workflow, List<TaskModel> tasks, String payload, Integer correlationId) {
+    private void handleConcurrentUpdate(WorkflowModel workflow, List<TaskModel> tasks, String payload, Long correlationId) {
         LOGGER.info("Concurrent update detected, update failed for workflow: {} retrying..", workflow.getWorkflowId());
         WorkflowModel retriedWorkflow = getWorkflow(workflow.getWorkflowId());
 
@@ -622,7 +622,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     @Override
     public boolean removeWorkflow(String workflowId) {
         WorkflowModel workflow = getWorkflow(workflowId, true);
-        Integer correlationId = Objects.isNull(workflow.getCorrelationId()) ? 0 : Integer.parseInt(workflow.getCorrelationId());
+        Long correlationId = Objects.isNull(workflow.getCorrelationId()) ? 0L : Long.parseLong(workflow.getCorrelationId());
         boolean removed = false;
         if (workflow != null) {
             try {
@@ -672,7 +672,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     public WorkflowModel getWorkflow(String workflowId, boolean includeTasks) {
         UUID workflowUUID = toUUID(workflowId, "Invalid workflow id");
         String shardId = lookupShardIdFromWorkflowId(workflowId);
-        Integer correlationId = Objects.isNull(shardId) ? 0 : Integer.parseInt(shardId);
+        Long correlationId = Objects.isNull(shardId) ? 0L : Long.parseLong(shardId);
 
         try {
             WorkflowModel workflow = null;
@@ -970,7 +970,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
             // get total tasks for this workflow
             WorkflowMetadata workflowMetadata = getWorkflowMetadata(task.getWorkflowInstanceId(),
                     task.getCorrelationId());
-            Integer correlationId = Objects.isNull(task.getCorrelationId()) ? 0 : Integer.parseInt(task.getCorrelationId());
+            Long correlationId = Objects.isNull(task.getCorrelationId()) ? 0L : Long.parseLong(task.getCorrelationId());
             int totalTasks = workflowMetadata.getTotalTasks();
 
             // remove from task_lookup table
@@ -1051,7 +1051,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
 
     @VisibleForTesting
     WorkflowMetadata getWorkflowMetadata(String workflowId, String correlationId) {
-        Integer corelId = Objects.isNull(correlationId) ? 0 : Integer.parseInt(correlationId);
+        Long corelId = Objects.isNull(correlationId) ? 0L : Long.parseLong(correlationId);
         ResultSet resultSet =
                 session.execute(selectTotalStatement.bind(UUID.fromString(workflowId),corelId));
         recordCassandraDaoRequests("getWorkflowMetadata");

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
@@ -533,7 +533,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
             List<TaskModel> tasks = workflow.getTasks();
             workflow.setTasks(new LinkedList<>());
             String payload = toJson(workflow);
-            Integer correlationId = Objects.isNull(workflow.getCorrelationId()) ? 0 : Integer.parseInt(workflow.getCorrelationId());
+            Long correlationId = Objects.isNull(workflow.getCorrelationId()) ? 0L : Long.parseLong(workflow.getCorrelationId());
             LOGGER.info(
                     "Correlation ID for workflow {} is {}",
                     workflow.getWorkflowId(),

--- a/scylla-persistence/src/test/groovy/com/netflix/conductor/scylla/dao/ScyllaExecutionDAOSpec.groovy
+++ b/scylla-persistence/src/test/groovy/com/netflix/conductor/scylla/dao/ScyllaExecutionDAOSpec.groovy
@@ -31,6 +31,9 @@ class ScyllaExecutionDAOSpec extends ScyllaSpec {
     @Subject
     ScyllaExecutionDAO executionDAO
 
+    private String correlationId = "2180000016"
+
+
     def setup() {
         executionDAO = new ScyllaExecutionDAO(session, objectMapper, cassandraProperties, statements)
     }
@@ -40,8 +43,8 @@ class ScyllaExecutionDAOSpec extends ScyllaSpec {
         def tasks = []
 
         // create tasks for a workflow and add to list
-        TaskModel task1 = new TaskModel(workflowInstanceId: 'uuid', taskId: 'task1id', referenceTaskName: 'task1')
-        TaskModel task2 = new TaskModel(workflowInstanceId: 'uuid', taskId: 'task2id', referenceTaskName: 'task2')
+        TaskModel task1 = new TaskModel(workflowInstanceId: 'uuid', taskId: 'task1id', referenceTaskName: 'task1', correlationId: correlationId)
+        TaskModel task2 = new TaskModel(workflowInstanceId: 'uuid', taskId: 'task2id', referenceTaskName: 'task2', correlationId: correlationId)
         tasks << task1 << task2
 
         when:
@@ -52,7 +55,7 @@ class ScyllaExecutionDAOSpec extends ScyllaSpec {
 
         and:
         // add a task from a different workflow to the list
-        TaskModel task3 = new TaskModel(workflowInstanceId: 'other-uuid', taskId: 'task3id', referenceTaskName: 'task3')
+        TaskModel task3 = new TaskModel(workflowInstanceId: 'other-uuid', taskId: 'task3id', referenceTaskName: 'task3', correlationId: correlationId)
         tasks << task3
 
         when:
@@ -66,7 +69,6 @@ class ScyllaExecutionDAOSpec extends ScyllaSpec {
     def "workflow CRUD"() {
         given:
         String workflowId = new IDGenerator().generate()
-        String correlationId = "2180000016";
         WorkflowDef workflowDef = new WorkflowDef()
         workflowDef.name = "def1"
         workflowDef.setVersion(1)
@@ -122,13 +124,13 @@ class ScyllaExecutionDAOSpec extends ScyllaSpec {
         given: 'we create a workflow'
         String workflowId = new IDGenerator().generate()
         WorkflowDef workflowDef = new WorkflowDef(name: 'def1', version: 1)
-        WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, input: new HashMap(), status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis())
+        WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, input: new HashMap(), status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis(), correlationId: correlationId)
         executionDAO.createWorkflow(workflow)
 
         and: 'create tasks for this workflow'
-        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
-        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
-        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
+        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
+        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
+        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
 
         def taskList = [task1, task2, task3]
 
@@ -199,9 +201,9 @@ class ScyllaExecutionDAOSpec extends ScyllaSpec {
         executionDAO.createWorkflow(workflow)
 
         and: 'create tasks for this workflow'
-        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
-        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
-        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
+        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
+        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
+        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
 
         and: 'add the tasks to the datastore'
         executionDAO.createTasks([task1, task2, task3])
@@ -233,13 +235,13 @@ class ScyllaExecutionDAOSpec extends ScyllaSpec {
         given: 'we create a workflow'
         String workflowId = new IDGenerator().generate()
         WorkflowDef workflowDef = new WorkflowDef(name: 'def1', version: 1)
-        WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, input: new HashMap(), status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis())
+        WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, input: new HashMap(), status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis(), correlationId: correlationId)
         executionDAO.createWorkflow(workflow)
 
         and: 'create tasks for this workflow'
-        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
-        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
-        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate())
+        TaskModel task1 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task1', referenceTaskName: 'task1', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
+        TaskModel task2 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task2', referenceTaskName: 'task2', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
+        TaskModel task3 = new TaskModel(workflowInstanceId: workflowId, taskType: 'task3', referenceTaskName: 'task3', status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), correlationId: correlationId)
 
         and: 'add the tasks to the datastore'
         executionDAO.createTasks([task1, task2, task3])
@@ -249,7 +251,7 @@ class ScyllaExecutionDAOSpec extends ScyllaSpec {
 
         then:
         removed
-        def workflowMetadata = executionDAO.getWorkflowMetadata(workflowId, "0")
+        def workflowMetadata = executionDAO.getWorkflowMetadata(workflowId, correlationId)
         workflowMetadata.totalTasks == 2
         workflowMetadata.totalPartitions == 1
 
@@ -291,6 +293,7 @@ class ScyllaExecutionDAOSpec extends ScyllaSpec {
         task.taskDefName = taskDefName
         task.taskId = taskId
         task.workflowInstanceId = new IDGenerator().generate()
+        task.setCorrelationId(correlationId)
         task.setWorkflowTask(workflowTask)
         task.setTaskType("test_task")
         task.setWorkflowType("test_workflow")
@@ -300,6 +303,7 @@ class ScyllaExecutionDAOSpec extends ScyllaSpec {
         newTask.setTaskDefName(taskDefName)
         newTask.setTaskId(new IDGenerator().generate())
         newTask.setWorkflowInstanceId(new IDGenerator().generate())
+        newTask.setCorrelationId(correlationId)
         newTask.setWorkflowTask(workflowTask)
         newTask.setTaskType("test_task")
         newTask.setWorkflowType("test_workflow")
@@ -411,7 +415,7 @@ class ScyllaExecutionDAOSpec extends ScyllaSpec {
         String workflowId = new IDGenerator().generate()
         WorkflowTask workflowTask = new WorkflowTask(taskDefinition: new TaskDef(concurrentExecLimit: 2))
         WorkflowDef workflowDef = new WorkflowDef(name: UUID.randomUUID().toString(), version: 1, tasks: [workflowTask])
-        WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis())
+        WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis(), correlationId: correlationId)
 
         when: 'serialize workflow'
         def workflowJson = objectMapper.writeValueAsString(workflow)
@@ -431,7 +435,7 @@ class ScyllaExecutionDAOSpec extends ScyllaSpec {
         given: 'define a workflow and tasks for this workflow'
         String workflowId = new IDGenerator().generate()
         WorkflowTask workflowTask = new WorkflowTask(taskDefinition: new TaskDef(concurrentExecLimit: 2))
-        TaskModel task = new TaskModel(workflowInstanceId: workflowId, taskType: UUID.randomUUID().toString(), referenceTaskName: UUID.randomUUID().toString(), status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), workflowTask: workflowTask)
+        TaskModel task = new TaskModel(workflowInstanceId: workflowId, taskType: UUID.randomUUID().toString(), referenceTaskName: UUID.randomUUID().toString(), status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), workflowTask: workflowTask, correlationId: correlationId)
 
         when: 'serialize task'
         def taskJson = objectMapper.writeValueAsString(task)
@@ -453,9 +457,9 @@ class ScyllaExecutionDAOSpec extends ScyllaSpec {
         WorkflowDef workflowDef = new WorkflowDef(name: UUID.randomUUID().toString(), version: 1, tasks: workflowTasks)
 
         def taskList = (0..999)
-                .collect { new TaskModel(workflowInstanceId: workflowId, taskType: it, referenceTaskName: it, status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), workflowTask: workflowTasks.get(it)) }
+                .collect { new TaskModel(workflowInstanceId: workflowId, taskType: it, referenceTaskName: it, status: TaskModel.Status.SCHEDULED, taskId: new IDGenerator().generate(), workflowTask: workflowTasks.get(it), correlationId: correlationId) }
 
-        WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis())
+        WorkflowModel workflow = new WorkflowModel(workflowDefinition: workflowDef, workflowId: workflowId, status: WorkflowModel.Status.RUNNING, createTime: System.currentTimeMillis(), correlationId: correlationId)
 
         and: 'create workflow'
         executionDAO.createWorkflow(workflow)
@@ -466,7 +470,7 @@ class ScyllaExecutionDAOSpec extends ScyllaSpec {
         println("Create 1000 tasks, duration: ${System.currentTimeMillis() - start_time} ms")
 
         then:
-        def workflowMetadata = executionDAO.getWorkflowMetadata(workflowId, "0")
+        def workflowMetadata = executionDAO.getWorkflowMetadata(workflowId, correlationId)
         workflowMetadata.totalTasks == 1000
 
         when: 'read workflow with tasks'

--- a/scylla-persistence/src/test/groovy/com/netflix/conductor/scylla/dao/ScyllaExecutionDAOSpec.groovy
+++ b/scylla-persistence/src/test/groovy/com/netflix/conductor/scylla/dao/ScyllaExecutionDAOSpec.groovy
@@ -66,12 +66,14 @@ class ScyllaExecutionDAOSpec extends ScyllaSpec {
     def "workflow CRUD"() {
         given:
         String workflowId = new IDGenerator().generate()
+        String correlationId = "2180000016";
         WorkflowDef workflowDef = new WorkflowDef()
         workflowDef.name = "def1"
         workflowDef.setVersion(1)
         WorkflowModel workflow = new WorkflowModel()
         workflow.setWorkflowDefinition(workflowDef)
         workflow.setWorkflowId(workflowId)
+        workflow.setCorrelationId(correlationId)
         workflow.setInput(new HashMap<>())
         workflow.setStatus(WorkflowModel.Status.RUNNING)
         workflow.setCreateTime(System.currentTimeMillis())


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
Changed data type for correlation id from Integer to Long.

_Describe the new behavior from this PR, and why it's needed_
Issue #
FR - https://freshworks.freshrelease.com/ws/FS/tasks/FS-222899
While triggering workflow in conductor, NumberFormatException is being thrown due to Integer limit breach for correlation id. Hence changed data type to Long.

Alternatives considered
----

_Describe alternative implementation you have considered_
