### PR TITLE
[FS-280753] - redis lock enabled for decide method

### DIFF
--- a/core/src/main/java/com/netflix/conductor/service/ExecutionLockService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionLockService.java
@@ -36,7 +36,7 @@ public class ExecutionLockService {
     private final long lockTimeToTry;
 
     @Autowired
-    public ExecutionLockService(ConductorProperties properties, @Qualifier("provideLock") Lock lock) {
+    public ExecutionLockService(ConductorProperties properties, @Qualifier("provideRedisLock") Lock lock) {
         this.properties = properties;
         this.lock = lock;
         this.lockLeaseTime = properties.getLockLeaseTime().toMillis();

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -70,8 +70,8 @@ conductor.default-event-queue.type=sqs
 # conductor.zookeeper-lock.namespace
 
 #disable locking during workflow execution
-conductor.app.workflow-execution-lock-enabled=false
-conductor.workflow-execution-lock.type=noop_lock
+conductor.app.workflow-execution-lock-enabled=true
+conductor.workflow-execution-lock.type=redis
 
 #Redis cluster settings for locking module
 # conductor.redis-lock.serverType=single


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

When executing workflows that utilize Fork/Join constructs where multiple sub-workflows run in parallel, we're encountering an issue where a single task (whether it's a system task or a custom task) is being scheduled multiple times with the same attempt number (attempt 0). This issue is easily reproducible in a local environment.
The root cause lies in Conductor's DeciderService (DeciderService#decide(com.netflix.conductor.model.WorkflowModel)), which is responsible for determining and scheduling the next set of tasks by placing them in a queue for task workers to pick up.
The current implementation schedules the next set of tasks based on their statuses retrieved from the workflow entity in the database, which reflects the most recent execution state. Once a task is selected for scheduling, it's marked as executed to prevent duplicate execution.
This decide method is invoked from multiple places such as after the workflow is initiated, upon task completion, and by the sweeper service (which handles rescheduling of timed-out tasks). In scenarios where two tasks (within a fork/join structure) complete concurrently on separate threads and invoke the decide method, the same task can be scheduled multiple times with the same attempt number.
The above decide method is called from  WorkflowExecutor#decide(java.lang.String)  which includes a locking mechanism to prevent such race conditions, we had disabled it under the assumption that only sequential workflows would be executed—where this issue doesn't occur.
However, after enabling the localOnly lock (already implemented in Conductor for single-instance deployments), the issue no longer reproduces locally. In production environments, we may need to rely on the Redis-based lock (also implemented and currently in use for task status updates). The Netflix Conductor community also strongly recommends enabling locking when working with parallel workflows (see [link](https://github.com/Netflix/conductor-community/blob/main/lock/README.md)).

![image](https://github.com/user-attachments/assets/c35b913f-0f1f-467f-b244-0cc1588ae47c)

Fix:
Enabled redis lock as suggested by the community.

Alternatives considered
----

_Describe alternative implementation you have considered_
