### PR TITLE
FS-308859

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -19,7 +19,6 @@ import static com.netflix.conductor.model.TaskModel.Status.FAILED_WITH_TERMINAL_
 import static com.netflix.conductor.model.TaskModel.Status.IN_PROGRESS;
 import static com.netflix.conductor.model.TaskModel.Status.SCHEDULED;
 import static com.netflix.conductor.model.TaskModel.Status.SKIPPED;
-import static com.netflix.conductor.model.TaskModel.Status.COMPLETED_WITH_ERRORS;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -19,6 +19,7 @@ import static com.netflix.conductor.model.TaskModel.Status.FAILED_WITH_TERMINAL_
 import static com.netflix.conductor.model.TaskModel.Status.IN_PROGRESS;
 import static com.netflix.conductor.model.TaskModel.Status.SCHEDULED;
 import static com.netflix.conductor.model.TaskModel.Status.SKIPPED;
+import static com.netflix.conductor.model.TaskModel.Status.COMPLETED_WITH_ERRORS;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1002,8 +1002,12 @@ public class WorkflowExecutor {
                         .collect(Collectors.toList());
 
         if (forkTasks.stream().anyMatch(fork -> fork.has(taskRefName))) {
-            return joinTasks.stream().anyMatch(join -> join.getJoinOn().contains(taskRefName))
-                    && task.getStatus().isSuccessful();
+            // JOIN is now synchronous and needs decide() to be called for re-evaluation
+            // Don't lazy evaluate - always call decide() when tasks in joinOn complete
+            boolean isInJoin = joinTasks.stream().anyMatch(join -> join.getJoinOn().contains(taskRefName));
+            if (isInJoin) {
+                return false;  // DON'T lazy evaluate - call decide() to re-evaluate JOIN
+            }
         }
 
         return workflowTasks.stream().noneMatch(t -> t.getTaskReferenceName().equals(taskRefName))
@@ -1098,6 +1102,7 @@ public class WorkflowExecutor {
 
             boolean stateChanged = scheduleTask(workflow, tasksToBeScheduled); // start
 
+            // Execute newly scheduled synchronous system tasks
             for (TaskModel task : outcome.tasksToBeScheduled) {
                 executionDAOFacade.populateTaskData(task);
                 if (systemTaskRegistry.isSystemTask(task.getTaskType())
@@ -1108,6 +1113,32 @@ public class WorkflowExecutor {
                             && workflowSystemTask.execute(workflow, task, this)) {
                         tasksToBeUpdated.add(task);
                         stateChanged = true;
+                    }
+                }
+            }
+
+            // Re-evaluate pending synchronous system tasks that are still IN_PROGRESS
+            // This ensures tasks like AWAIT_COMPLETION are checked on every decide() call
+            for (TaskModel task : workflow.getTasks()) {
+                if (systemTaskRegistry.isSystemTask(task.getTaskType())
+                        && task.getStatus() == TaskModel.Status.IN_PROGRESS
+                        && !task.isExecuted()
+                        && !outcome.tasksToBeScheduled.contains(task)) {
+                    WorkflowSystemTask workflowSystemTask =
+                            systemTaskRegistry.get(task.getTaskType());
+                    if (!workflowSystemTask.isAsync()) {
+                        LOGGER.debug(
+                                "Re-evaluating pending sync system task: {}/{}",
+                                task.getTaskType(),
+                                task.getTaskId());
+                        if (workflowSystemTask.execute(workflow, task, this)) {
+                            tasksToBeUpdated.add(task);
+                            stateChanged = true;
+                            LOGGER.debug(
+                                    "Pending sync system task completed: {}/{}",
+                                    task.getTaskType(),
+                                    task.getTaskId());
+                        }
                     }
                 }
             }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
@@ -110,8 +110,8 @@ public class Join extends WorkflowSystemTask {
 
     @Override
     public boolean isAsync() {
-        // JOIN tasks are executed synchronously in the decide flow
-        // They only check in-memory task statuses and don't require async polling
+        // JOIN executes synchronously for immediate completion when join conditions are met
+        // It is re-evaluated on every decide() call when tasks in joinOn list complete
         return false;
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
@@ -108,7 +108,10 @@ public class Join extends WorkflowSystemTask {
         return Optional.of(Math.min((long) Math.pow(2, index), defaultOffset));
     }
 
+    @Override
     public boolean isAsync() {
-        return true;
+        // JOIN tasks are executed synchronously in the decide flow
+        // They only check in-memory task statuses and don't require async polling
+        return false;
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

**Changes in this PR**
Fixed Join task closure delay issue. Made Join task Synchronous task instead of Async, changing from poll and execute approach to re-evaluation of JOIN task on every execution of JOIN task.

**_Describe the new behavior from this PR, and why it's needed_**
Issue # JOIN task delay seen due to poll and execute and join task queue getting bloated due to this approach.

**_Describe alternative implementation you have considered_**
 Made Join task Synchronous task instead of Async, changing from poll and execute approach to re-evaluation of JOIN task on every execution of JOIN task within conductor.
 
 **Files changed**
 core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
 core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
 