### PR TITLE
[FS-308859] - CaaS Performance Bug, JR and Phase status takes too long to update

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -43,10 +43,7 @@ public class ConductorProperties {
     private Duration workflowOffsetTimeout = Duration.ofSeconds(300);
 
     /** The number of threads to use to do background sweep on active workflows. */
-    private int sweeperThreadCount;
-
-    /** The thread multipler factor for the sweeper thread. */
-    private int sweeperThreadMultiplier = 2;
+    private int sweeperThreadCount = Runtime.getRuntime().availableProcessors() * 2;
 
     /** The timeout (in milliseconds) for the polling of workflows to be swept. */
     private Duration sweeperWorkflowPollTimeout = Duration.ofMillis(2000);
@@ -248,16 +245,8 @@ public class ConductorProperties {
         this.workflowOffsetTimeout = workflowOffsetTimeout;
     }
 
-    public int getSweeperThreadMultiplier() {
-        return sweeperThreadMultiplier;
-    }
-
-    public void setSweeperThreadMultiplier(int sweeperThreadMultiplier) {
-        this.sweeperThreadMultiplier = sweeperThreadMultiplier;
-    }
-
     public int getSweeperThreadCount() {
-        return Runtime.getRuntime().availableProcessors() * getSweeperThreadMultiplier();
+        return sweeperThreadCount;
     }
 
     public void setSweeperThreadCount(int sweeperThreadCount) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -996,8 +996,12 @@ public class WorkflowExecutor {
                         .collect(Collectors.toList());
 
         if (forkTasks.stream().anyMatch(fork -> fork.has(taskRefName))) {
-            return joinTasks.stream().anyMatch(join -> join.getJoinOn().contains(taskRefName))
-                    && task.getStatus().isSuccessful();
+            // JOIN is now synchronous and needs decide() to be called for re-evaluation
+            // Don't lazy evaluate - always call decide() when tasks in joinOn complete
+            boolean isInJoin = joinTasks.stream().anyMatch(join -> join.getJoinOn().contains(taskRefName));
+            if (isInJoin) {
+                return false;  // DON'T lazy evaluate - call decide() to re-evaluate JOIN
+            }
         }
 
         return workflowTasks.stream().noneMatch(t -> t.getTaskReferenceName().equals(taskRefName))
@@ -1109,6 +1113,7 @@ public class WorkflowExecutor {
 
             boolean stateChanged = scheduleTask(workflow, tasksToBeScheduled); // start
 
+            // Execute newly scheduled synchronous system tasks
             for (TaskModel task : outcome.tasksToBeScheduled) {
                 executionDAOFacade.populateTaskData(task);
                 if (systemTaskRegistry.isSystemTask(task.getTaskType())
@@ -1119,6 +1124,27 @@ public class WorkflowExecutor {
                             && workflowSystemTask.execute(workflow, task, this)) {
                         tasksToBeUpdated.add(task);
                         stateChanged = true;
+                    }
+                }
+            }
+
+            // Re-evaluate pending JOIN tasks that are still IN_PROGRESS
+            // JOIN is now synchronous and needs to be checked on every decide() call
+            // when tasks in its joinOn list complete
+            for (TaskModel task : workflow.getTasks()) {
+                if (TaskType.TASK_TYPE_JOIN.equals(task.getTaskType())
+                        && task.getStatus() == TaskModel.Status.IN_PROGRESS
+                        && !task.isExecuted()
+                        && !outcome.tasksToBeScheduled.contains(task)) {
+                    WorkflowSystemTask workflowSystemTask =
+                            systemTaskRegistry.get(task.getTaskType());
+                    // Safety check: only re-evaluate if JOIN is configured as synchronous
+                    if (!workflowSystemTask.isAsync()) {
+                        // execute() returns true if JOIN condition is met and task status changed to terminal
+                        if (workflowSystemTask.execute(workflow, task, this)) {
+                            tasksToBeUpdated.add(task);
+                            stateChanged = true;
+                        }
                     }
                 }
             }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1142,6 +1142,12 @@ public class WorkflowExecutor {
                     if (!workflowSystemTask.isAsync()) {
                         // execute() returns true if JOIN condition is met and task status changed to terminal
                         if (workflowSystemTask.execute(workflow, task, this)) {
+                            LOGGER.info(
+                                    "JOIN task completed: taskId={}, taskType={}, status={}, workflowId={}",
+                                    task.getTaskId(),
+                                    task.getTaskType(),
+                                    task.getStatus(),
+                                    workflow.getWorkflowId());
                             tasksToBeUpdated.add(task);
                             stateChanged = true;
                         }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
@@ -108,7 +108,10 @@ public class Join extends WorkflowSystemTask {
         return Optional.of(Math.min((long) Math.pow(2, index), defaultOffset));
     }
 
+    @Override
     public boolean isAsync() {
-        return true;
+        // JOIN executes synchronously for immediate completion when join conditions are met
+        // It is re-evaluated on every decide() call when tasks in joinOn list complete
+        return false;
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowReconciler.java
+++ b/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowReconciler.java
@@ -54,8 +54,8 @@ public class WorkflowReconciler extends LifecycleAwareComponent {
         this.sweeperWorkflowPollTimeout =
                 (int) properties.getSweeperWorkflowPollTimeout().toMillis();
         LOGGER.info(
-                "WorkflowReconciler initialized with {} sweeper threads , sweeper Poll {}",
-                properties.getSweeperThreadCount(),properties.getSweeperWorkflowPollTimeout());
+                "WorkflowReconciler initialized with {} sweeper threads",
+                properties.getSweeperThreadCount());
     }
 
     @Scheduled(
@@ -94,6 +94,7 @@ public class WorkflowReconciler extends LifecycleAwareComponent {
 
     private void recordQueueDepth() {
         int currentQueueSize = queueDAO.getSize(DECIDER_QUEUE);
+        LOGGER.info("[SWEEPER] Decider queue size: {}", currentQueueSize);
         Monitors.recordGauge(DECIDER_QUEUE, currentQueueSize);
     }
 }

--- a/docker/server/config/config-conductor-server.properties
+++ b/docker/server/config/config-conductor-server.properties
@@ -9,8 +9,6 @@ conductor.app.workflow-execution-lock-enabled=${WORKFLOW_EXECUTION_LOCK_ENABLED}
 conductor.workflow-execution-lock.type=${WORKFLOW_EXECUTION_LOCK_TYPE}
 
 conductor.app.stack=staging
-conductor.app.sweeperThreadMultiplier=${SWEEPER_THREAD_MULTIPLIER}
-conductor.app.sweeperWorkflowPollTimeout=${SWEEPER_POLL_TIMEOUT}
 
 # Database persistence type.
 conductor.db.type=scylla


### PR DESCRIPTION
[FS-308859](https://freshworks.freshrelease.com/ws/FS/tasks/FS-308859) - CaaS Performance Bug, JR and Phase status takes too long to update
Reverted sweeper thread config changes done by @logesh

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
Fixed Join task closure delay issue. Made Join task Synchronous task instead of Async, changing from poll and execute approach to re-evaluation of JOIN task on every execution of JOIN task.

Describe the new behavior from this PR, and why it's needed
Issue # JOIN task delay seen due to poll and execute and join task queue getting bloated due to this approach.

Describe alternative implementation you have considered
Made Join task Synchronous task instead of Async, changing from poll and execute approach to re-evaluation of JOIN task on every execution of JOIN task within conductor.

Files changed
core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
