### PR TITLE
[FS-350048] - Introduced new tables for workflow execution tables and handled fallback.

### DIFF
--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraExecutionDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraExecutionDAO.java
@@ -565,9 +565,15 @@ public class CassandraExecutionDAO extends CassandraBaseDAO
     @Override
     public boolean removeWorkflow(String workflowId) {
         WorkflowModel workflow = getWorkflow(workflowId, true);
+        return removeWorkflow(workflow);
+    }
+
+    @Override
+    public boolean removeWorkflow(WorkflowModel workflow) {
         Integer correlationId = Objects.isNull(workflow.getCorrelationId()) ? 0 : Integer.parseInt(workflow.getCorrelationId());
         boolean removed = false;
         if (workflow != null) {
+            String workflowId = workflow.getWorkflowId();
             try {
                 recordCassandraDaoRequests("removeWorkflow", "n/a", workflow.getWorkflowName());
                 ResultSet resultSet =

--- a/core/src/main/java/com/netflix/conductor/core/dal/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/dal/ExecutionDAOFacade.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.conductor.common.metadata.events.EventExecution;
 import com.netflix.conductor.common.metadata.tasks.PollData;
 import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.tasks.TaskExecLog;
 import com.netflix.conductor.common.run.SearchResult;
@@ -375,8 +376,11 @@ public class ExecutionDAOFacade {
      */
     public void removeWorkflow(String workflowId, boolean archiveWorkflow) {
         WorkflowModel workflow = getWorkflowModelFromDataStore(workflowId, true);
+        removeWorkflow(workflow, archiveWorkflow);
+    }
 
-        executionDAO.removeWorkflow(workflowId);
+    public void removeWorkflow(WorkflowModel workflow, boolean archiveWorkflow) {
+        executionDAO.removeWorkflow(workflow);
         try {
             removeWorkflowIndex(workflow, archiveWorkflow);
         } catch (JsonProcessingException e) {
@@ -401,7 +405,7 @@ public class ExecutionDAOFacade {
                             } catch (Exception e) {
                                 LOGGER.info(
                                         "Error removing task: {} of workflow: {} from {} queue",
-                                        workflowId,
+                                        workflow.getWorkflowId(),
                                         task.getTaskId(),
                                         QueueUtils.getQueueName(task),
                                         e);
@@ -409,9 +413,9 @@ public class ExecutionDAOFacade {
                         });
 
         try {
-            queueDAO.remove(DECIDER_QUEUE, workflowId);
+            queueDAO.remove(DECIDER_QUEUE, workflow.getWorkflowId());
         } catch (Exception e) {
-            LOGGER.info("Error removing workflow: {} from decider queue", workflowId, e);
+            LOGGER.info("Error removing workflow: {} from decider queue", workflow.getWorkflowId(), e);
         }
     }
 
@@ -432,13 +436,17 @@ public class ExecutionDAOFacade {
                                 workflow.getWorkflowId(), workflow.getStatus()));
             }
         } else {
-            // Not archiving, also remove workflow from index
-            indexDAO.asyncRemoveWorkflow(workflow.getWorkflowId());
+            // Delete synchronously so workflow docs do not linger after primary-store deletion.
+            indexDAO.removeWorkflow(workflow.getWorkflowId());
         }
     }
 
-    public void removeWorkflow(WorkflowModel workflow) {
-        executionDAO.removeWorkflow(workflow);
+    public void scheduleWorkflowDeletion(String workflowId) {
+        LOGGER.info("Scheduling workflow for deletion {}", workflowId);
+        scheduledThreadPoolExecutor.schedule(
+                new DeleteWorkflowOnCompletion(workflowId),
+                properties.getAsyncUpdateDelay().getSeconds(),
+                TimeUnit.SECONDS);
     }
 
     public void removeWorkflowWithExpiry(
@@ -606,8 +614,8 @@ public class ExecutionDAOFacade {
                                 task.getTaskId(), workflow.getWorkflowId(), task.getStatus()));
             }
         } else {
-            // Not archiving, remove task from index
-            indexDAO.asyncRemoveTask(workflow.getWorkflowId(), task.getTaskId());
+            // Delete synchronously so task docs do not linger after primary-store deletion.
+            indexDAO.removeTask(workflow.getWorkflowId(), task.getTaskId());
         }
     }
 
@@ -815,10 +823,85 @@ public class ExecutionDAOFacade {
         public void run() {
             try {
                 WorkflowModel workflowModel = executionDAO.getWorkflow(workflowId, false);
+                if (workflowModel == null) {
+                    LOGGER.debug(
+                            "Skipping delayed index update for workflow {} because it no longer exists",
+                            workflowId);
+                    return;
+                }
                 indexDAO.asyncIndexWorkflow(new WorkflowSummary(workflowModel.toWorkflow()));
             } catch (Exception e) {
                 LOGGER.error("Unable to update workflow: {}", workflowId, e);
             }
         }
+    }
+
+    class DeleteWorkflowOnCompletion implements Runnable {
+
+        private final String workflowId;
+
+        DeleteWorkflowOnCompletion(String workflowId) {
+            this.workflowId = workflowId;
+        }
+
+        @Override
+        public void run() {
+            try {
+                WorkflowModel workflow = executionDAO.getWorkflow(workflowId, true);
+                if (workflow == null) {
+                    LOGGER.debug(
+                            "Skipping deletion for workflow {} because it no longer exists",
+                            workflowId);
+                    return;
+                }
+
+                if (isDeletionEligibleAfterCompletion(workflow)) {
+                    deleteCompletedWorkflowHierarchy(workflow);
+                } else {
+                    LOGGER.debug(
+                            "Workflow {} is not eligible for deletion after completion yet",
+                            workflowId);
+                }
+            } catch (Exception e) {
+                LOGGER.error("Unable to delete completed workflow: {}", workflowId, e);
+            }
+        }
+    }
+
+    private boolean isDeletionEligibleAfterCompletion(WorkflowModel workflow) {
+        if (!WorkflowModel.Status.COMPLETED.equals(workflow.getStatus())) {
+            return false;
+        }
+
+        String parentWorkflowId = workflow.getParentWorkflowId();
+        while (StringUtils.isNotBlank(parentWorkflowId)) {
+            WorkflowModel parentWorkflow = executionDAO.getWorkflow(parentWorkflowId, false);
+            if (parentWorkflow == null) {
+                return true;
+            }
+            if (!WorkflowModel.Status.COMPLETED.equals(parentWorkflow.getStatus())) {
+                return false;
+            }
+            parentWorkflowId = parentWorkflow.getParentWorkflowId();
+        }
+        return true;
+    }
+
+    private void deleteCompletedWorkflowHierarchy(WorkflowModel workflow) {
+        workflow.getTasks().stream()
+                .filter(task -> TaskType.TASK_TYPE_SUB_WORKFLOW.equals(task.getTaskType()))
+                .map(TaskModel::getSubWorkflowId)
+                .filter(StringUtils::isNotBlank)
+                .forEach(
+                        subWorkflowId -> {
+                            WorkflowModel subWorkflow = executionDAO.getWorkflow(subWorkflowId, true);
+                            if (subWorkflow != null
+                                    && WorkflowModel.Status.COMPLETED.equals(subWorkflow.getStatus())
+                                    && isDeletionEligibleAfterCompletion(subWorkflow)) {
+                                deleteCompletedWorkflowHierarchy(subWorkflow);
+                            }
+                        });
+
+        removeWorkflow(workflow, false);
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/dal/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/dal/ExecutionDAOFacade.java
@@ -437,6 +437,10 @@ public class ExecutionDAOFacade {
         }
     }
 
+    public void removeWorkflow(WorkflowModel workflow) {
+        executionDAO.removeWorkflow(workflow);
+    }
+
     public void removeWorkflowWithExpiry(
             String workflowId, boolean archiveWorkflow, int ttlSeconds) {
         try {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -516,68 +516,73 @@ public class WorkflowExecutor {
     @VisibleForTesting
     WorkflowModel completeWorkflow(WorkflowModel workflow) {
         LOGGER.debug("Completing workflow execution for {}", workflow.getWorkflowId());
+        try {
+            if (workflow.getStatus().equals(WorkflowModel.Status.COMPLETED)) {
+                queueDAO.remove(DECIDER_QUEUE, workflow.getWorkflowId()); // remove from the sweep queue
+                executionDAOFacade.removeFromPendingWorkflow(
+                        workflow.getWorkflowName(), workflow.getWorkflowId());
+                executionDAOFacade.scheduleWorkflowDeletion(workflow.getWorkflowId());
+                LOGGER.debug("Workflow: {} has already been completed.", workflow.getWorkflowId());
+                return workflow;
+            }
 
-        if (workflow.getStatus().equals(WorkflowModel.Status.COMPLETED)) {
+            if (workflow.getStatus().isTerminal()) {
+                String msg =
+                        "Workflow is already in terminal state. Current status: "
+                                + workflow.getStatus();
+                throw new ConflictException(msg);
+            }
+
+            deciderService.updateWorkflowOutput(workflow, null);
+
+            workflow.setStatus(WorkflowModel.Status.COMPLETED);
+
+            // update the failed reference task names
+            List<TaskModel> failedTasks =
+                    workflow.getTasks().stream()
+                            .filter(
+                                    t ->
+                                            FAILED.equals(t.getStatus())
+                                                    || FAILED_WITH_TERMINAL_ERROR.equals(
+                                                            t.getStatus()))
+                            .collect(Collectors.toList());
+
+            workflow.getFailedReferenceTaskNames()
+                    .addAll(
+                            failedTasks.stream()
+                                    .map(TaskModel::getReferenceTaskName)
+                                    .collect(Collectors.toSet()));
+
+            workflow.getFailedTaskNames()
+                    .addAll(
+                            failedTasks.stream()
+                                    .map(TaskModel::getTaskDefName)
+                                    .collect(Collectors.toSet()));
+
+            executionDAOFacade.updateWorkflow(workflow);
+            LOGGER.debug("Completed workflow execution for {}", workflow.getWorkflowId());
+            workflowStatusListener.onWorkflowCompletedIfEnabled(workflow);
+            Monitors.recordWorkflowCompletion(
+                    workflow.getEndTime() - workflow.getCreateTime(),
+                    workflow.getOwnerApp());
+
+            if (workflow.hasParent()) {
+                updateParentWorkflowTask(workflow);
+                LOGGER.info(
+                        "{} updated parent {} task {}",
+                        workflow.toShortString(),
+                        workflow.getParentWorkflowId(),
+                        workflow.getParentWorkflowTaskId());
+                expediteLazyWorkflowEvaluation(workflow.getParentWorkflowId());
+            }
+
             queueDAO.remove(DECIDER_QUEUE, workflow.getWorkflowId()); // remove from the sweep queue
-            executionDAOFacade.removeFromPendingWorkflow(
-                    workflow.getWorkflowName(), workflow.getWorkflowId());
-            LOGGER.debug("Workflow: {} has already been completed.", workflow.getWorkflowId());
+            executionDAOFacade.scheduleWorkflowDeletion(workflow.getWorkflowId());
             return workflow;
+        } finally {
+            executionLockService.releaseLock(workflow.getWorkflowId());
+            executionLockService.deleteLock(workflow.getWorkflowId());
         }
-
-        if (workflow.getStatus().isTerminal()) {
-            String msg =
-                    "Workflow is already in terminal state. Current status: "
-                            + workflow.getStatus();
-            throw new ConflictException(msg);
-        }
-
-        deciderService.updateWorkflowOutput(workflow, null);
-
-        workflow.setStatus(WorkflowModel.Status.COMPLETED);
-
-        // update the failed reference task names
-        List<TaskModel> failedTasks =
-                workflow.getTasks().stream()
-                        .filter(
-                                t ->
-                                        FAILED.equals(t.getStatus())
-                                                || FAILED_WITH_TERMINAL_ERROR.equals(t.getStatus()))
-                        .collect(Collectors.toList());
-
-        workflow.getFailedReferenceTaskNames()
-                .addAll(
-                        failedTasks.stream()
-                                .map(TaskModel::getReferenceTaskName)
-                                .collect(Collectors.toSet()));
-
-        workflow.getFailedTaskNames()
-                .addAll(
-                        failedTasks.stream()
-                                .map(TaskModel::getTaskDefName)
-                                .collect(Collectors.toSet()));
-
-        executionDAOFacade.updateWorkflow(workflow);
-        LOGGER.debug("Completed workflow execution for {}", workflow.getWorkflowId());
-        workflowStatusListener.onWorkflowCompletedIfEnabled(workflow);
-        Monitors.recordWorkflowCompletion(
-                workflow.getEndTime() - workflow.getCreateTime(),
-                workflow.getOwnerApp());
-
-        if (workflow.hasParent()) {
-            updateParentWorkflowTask(workflow);
-            LOGGER.info(
-                    "{} updated parent {} task {}",
-                    workflow.toShortString(),
-                    workflow.getParentWorkflowId(),
-                    workflow.getParentWorkflowTaskId());
-            expediteLazyWorkflowEvaluation(workflow.getParentWorkflowId());
-        }
-        executionDAOFacade.removeWorkflow(workflow);
-
-        executionLockService.releaseLock(workflow.getWorkflowId());
-        executionLockService.deleteLock(workflow.getWorkflowId());
-        return workflow;
     }
 
     public void terminateWorkflow(String workflowId, String reason) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -573,6 +573,7 @@ public class WorkflowExecutor {
                     workflow.getParentWorkflowTaskId());
             expediteLazyWorkflowEvaluation(workflow.getParentWorkflowId());
         }
+        executionDAOFacade.removeWorkflow(workflow);
 
         executionLockService.releaseLock(workflow.getWorkflowId());
         executionLockService.deleteLock(workflow.getWorkflowId());

--- a/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
@@ -123,6 +123,8 @@ public interface ExecutionDAO {
      */
     boolean removeWorkflow(String workflowId);
 
+    boolean removeWorkflow(WorkflowModel workflow);
+
     /**
      * Removes the workflow with ttl seconds
      *

--- a/docker/server/config/config-conductor-server.properties
+++ b/docker/server/config/config-conductor-server.properties
@@ -60,3 +60,5 @@ loadSample=${WORKFLOW_EXECUTION_LOAD_SAMPLE}
 concurrencyLimitEnabled=${WORKFLOW_EXECUTION_TASK_CONCURRENCY_LIMIT_ENABLED}
 # Migration flag to switch to new table task_in_progress_v2
 fallbackToOldTaskInProgressActive=${WORKFLOW_EXECUTION_FALLBACK_TO_TASK_IN_PROGRESS_ACTIVE}
+# Migration flag to switch to new workflow execution tables
+fallbackToOldWorkflowExecutionTables=${FALLBACK_TO_OLD_WORKFLOW_EXECUTION_TABLES}

--- a/redis-persistence/src/main/java/com/netflix/conductor/redis/dao/RedisExecutionDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/redis/dao/RedisExecutionDAO.java
@@ -430,7 +430,13 @@ public class RedisExecutionDAO extends BaseDynoDAO
     @Override
     public boolean removeWorkflow(String workflowId) {
         WorkflowModel workflow = getWorkflow(workflowId, true);
+        return removeWorkflow(workflow);
+    }
+
+    @Override
+    public boolean removeWorkflow(WorkflowModel workflow) {
         if (workflow != null) {
+            String workflowId = workflow.getWorkflowId();
             recordRedisDaoRequests("removeWorkflow");
 
             // Remove from lists

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaBaseDAO.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaBaseDAO.java
@@ -94,7 +94,9 @@ public abstract class ScyllaBaseDAO {
             if (!initialized) {
                 session.execute(getCreateKeyspaceStatement());
                 session.execute(getCreateWorkflowsTableStatement());
+                session.execute(getCreateWorkflowsTableV2Statement());
                 session.execute(getCreateTaskLookupTableStatement());
+                session.execute(getCreateTaskLookupTableV2Statement());
                 session.execute(getCreateTaskDefLimitTableStatement());
                 session.execute(getCreateWorkflowDefsTableStatement());
                 session.execute(getCreateWorkflowDefsIndexTableStatement());
@@ -105,6 +107,7 @@ public abstract class ScyllaBaseDAO {
                 //Added task_in_progress_v2
                 session.execute(getCreateTaskInProgressTableV2Statement());
                 session.execute(getCreateWorkflowLookupTableStatement());
+                session.execute(getCreateWorkflowLookupTableV2Statement());
                 session.execute(getCreateEventHandlersTableStatement());
                 session.execute(getCreateEventExecutionsTableStatement());
                 LOGGER.info(
@@ -145,8 +148,31 @@ public abstract class ScyllaBaseDAO {
                 .getQueryString();
     }
 
+    private String getCreateWorkflowsTableV2Statement() {
+        return SchemaBuilder.createTable(properties.getKeyspace(), TABLE_WORKFLOWS_V2)
+                .ifNotExists()
+                .addPartitionKey(WORKFLOW_ID_KEY, DataType.uuid())
+                .addPartitionKey(SHARD_ID_KEY, DataType.cint())
+                .addClusteringColumn(ENTITY_KEY, DataType.text())
+                .addClusteringColumn(TASK_ID_KEY, DataType.text())
+                .addColumn(PAYLOAD_KEY, DataType.text())
+                .addColumn(VERSION, DataType.cint())
+                .addStaticColumn(TOTAL_TASKS_KEY, DataType.cint())
+                .addStaticColumn(TOTAL_PARTITIONS_KEY, DataType.cint())
+                .getQueryString();
+    }
+
     private String getCreateTaskLookupTableStatement() {
         return SchemaBuilder.createTable(properties.getKeyspace(), TABLE_TASK_LOOKUP)
+                .ifNotExists()
+                .addPartitionKey(TASK_ID_KEY, DataType.uuid())
+                .addColumn(SHARD_ID_KEY,DataType.cint())
+                .addColumn(WORKFLOW_ID_KEY, DataType.uuid())
+                .getQueryString();
+    }
+
+    private String getCreateTaskLookupTableV2Statement() {
+        return SchemaBuilder.createTable(properties.getKeyspace(), TABLE_TASK_LOOKUP_V2)
                 .ifNotExists()
                 .addPartitionKey(TASK_ID_KEY, DataType.uuid())
                 .addColumn(SHARD_ID_KEY,DataType.cint())
@@ -159,6 +185,14 @@ public abstract class ScyllaBaseDAO {
      */
     private String getCreateWorkflowLookupTableStatement() {
         return SchemaBuilder.createTable(properties.getKeyspace(), TABLE_WORKFLOW_LOOKUP)
+                .ifNotExists()
+                .addPartitionKey(WORKFLOW_ID_KEY, DataType.uuid())
+                .addColumn(SHARD_ID_KEY,DataType.cint())
+                .getQueryString();
+    }
+
+    private String getCreateWorkflowLookupTableV2Statement() {
+        return SchemaBuilder.createTable(properties.getKeyspace(), TABLE_WORKFLOW_LOOKUP_V2)
                 .ifNotExists()
                 .addPartitionKey(WORKFLOW_ID_KEY, DataType.uuid())
                 .addColumn(SHARD_ID_KEY,DataType.cint())

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
@@ -92,6 +92,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     protected final PreparedStatement selectTotalV2Statement;
     protected final PreparedStatement selectTaskV2Statement;
     protected final PreparedStatement selectWorkflowV2Statement;
+    protected final PreparedStatement selectWorkflowWritetimeV2Statement;
     protected final PreparedStatement selectWorkflowWithTasksV2Statement;
     protected final PreparedStatement selectTaskLookupV2Statement;
     protected final PreparedStatement selectShardFromTaskLookupStatement;
@@ -249,6 +250,9 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         this.selectWorkflowV2Statement =
                 session.prepare(statements.getSelectWorkflowV2Statement())
                         .setConsistencyLevel(properties.getReadConsistencyLevel());
+        this.selectWorkflowWritetimeV2Statement =
+                session.prepare(statements.getSelectWorkflowWritetimeV2Statement())
+                        .setConsistencyLevel(properties.getWriteConsistencyLevel());
         this.selectWorkflowWithTasksStatement =
                 session.prepare(statements.getSelectWorkflowWithTasksStatement())
                         .setConsistencyLevel(properties.getReadConsistencyLevel());
@@ -917,11 +921,9 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
      */
     private long queryWorkflowEntityWriteTimestamp(String workflowId, int correlationId) {
         try {
-            String cql = String.format(
-                    "SELECT WRITETIME(payload) AS wt FROM %s.workflows_v2 "
-                    + "WHERE workflow_id=%s AND shard_id=%d AND entity='workflow' AND task_id=''",
-                    properties.getKeyspace(), workflowId, correlationId);
-            ResultSet rs = session.execute(cql);
+            ResultSet rs = session.execute(
+                    selectWorkflowWritetimeV2Statement.bind(
+                            UUID.fromString(workflowId), correlationId));
             Row row = rs.one();
             return (row != null) ? row.getLong("wt") : 0;
         } catch (Exception e) {

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
@@ -995,11 +995,12 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     }
 
     private WorkflowModel getWorkflowModelWithTasks(String workflowId, UUID workflowUUID, Integer correlationId) {
-        List<Row> rows;
+        List<Row> rows = null;
         if (fallbackToOldWorkflowExecutionTables) {
             rows = session.execute(
                     selectWorkflowWithTasksStatement.bind(workflowUUID, correlationId)).all();
-        } else {
+        }
+        if (rows == null || rows.isEmpty()) {
             rows = session.execute(
                     selectWorkflowWithTasksV2Statement.bind(workflowUUID, correlationId)).all();
         }
@@ -1035,13 +1036,14 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     }
 
     private WorkflowModel getWorkflowModelWithoutTasks(UUID workflowUUID, Integer correlationId) {
-        ResultSet resultSet;
+        Row row = null;
         if (fallbackToOldWorkflowExecutionTables) {
-            resultSet = session.execute(selectWorkflowStatement.bind(workflowUUID, correlationId));;
-        } else {
-            resultSet = session.execute(selectWorkflowV2Statement.bind(workflowUUID, correlationId));;
+            row = session.execute(selectWorkflowStatement.bind(workflowUUID, correlationId)).one();
         }
-        return Optional.ofNullable(resultSet.one())
+        if (row == null) {
+            row = session.execute(selectWorkflowV2Statement.bind(workflowUUID, correlationId)).one();
+        }
+        return Optional.ofNullable(row)
                 .map(
                         r -> {
                             WorkflowModel wf =
@@ -1114,11 +1116,12 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         try{
             recordCassandraDaoRequests("getWorkflowsByCorrelationId", "n/a", correlationId);
 
-            List<Row> rows;
+            List<Row> rows = null;
             if (fallbackToOldWorkflowExecutionTables) {
                 rows = session.execute(
                         selectWorkflowsByCorIdFromWorkflowStatement.bind(Integer.parseInt(correlationId))).all();
-            } else {
+            }
+            if (rows == null || rows.isEmpty()) {
                 rows = session.execute(
                         selectWorkflowsByCorIdFromWorkflowV2Statement.bind(Integer.parseInt(correlationId))).all();
             }
@@ -1396,16 +1399,17 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     @VisibleForTesting
     WorkflowMetadata getWorkflowMetadata(String workflowId, String correlationId) {
         Integer corelId = Objects.isNull(correlationId) ? 0 : Integer.parseInt(correlationId);
-        ResultSet resultSet;
+        Row row = null;
         if (fallbackToOldWorkflowExecutionTables) {
-            resultSet = session.execute(selectTotalStatement.bind(UUID.fromString(workflowId), corelId));
-        } else {
-            resultSet = session.execute(selectTotalV2Statement.bind(UUID.fromString(workflowId), corelId));
+            row = session.execute(selectTotalStatement.bind(UUID.fromString(workflowId), corelId)).one();
+        }
+        if (row == null) {
+            row = session.execute(selectTotalV2Statement.bind(UUID.fromString(workflowId), corelId)).one();
         }
 
         recordCassandraDaoRequests("getWorkflowMetadata");
 
-        return Optional.ofNullable(resultSet.one())
+        return Optional.ofNullable(row)
                 .map(
                         currentRow -> {
                             WorkflowMetadata workflowMetadata = new WorkflowMetadata();
@@ -1424,13 +1428,14 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     String lookupWorkflowIdFromTaskId(String taskId) {
         UUID taskUUID = toUUID(taskId, "Invalid task id");
         try {
-            ResultSet resultSet;
+            Row row = null;
             if (fallbackToOldWorkflowExecutionTables) {
-                resultSet = session.execute(selectTaskLookupStatement.bind(taskUUID));
-            } else {
-                resultSet = session.execute(selectTaskLookupV2Statement.bind(taskUUID));;
+                row = session.execute(selectTaskLookupStatement.bind(taskUUID)).one();
             }
-            return Optional.ofNullable(resultSet.one())
+            if (row == null) {
+                row = session.execute(selectTaskLookupV2Statement.bind(taskUUID)).one();
+            }
+            return Optional.ofNullable(row)
                     .map(r -> r.getUUID(WORKFLOW_ID_KEY).toString())
                     .orElse(null);
         } catch (DriverException e) {
@@ -1449,13 +1454,14 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     String lookupShardIdFromTaskId(String taskId) {
         UUID taskUUID = toUUID(taskId, "Invalid task id");
         try {
-            ResultSet resultSet;
+            Row row = null;
             if (fallbackToOldWorkflowExecutionTables) {
-                resultSet = session.execute(selectShardFromTaskLookupStatement.bind(taskUUID));;
-            } else {
-                resultSet = session.execute(selectShardFromTaskLookupV2Statement.bind(taskUUID));
+                row = session.execute(selectShardFromTaskLookupStatement.bind(taskUUID)).one();
             }
-            return Optional.ofNullable(resultSet.one())
+            if (row == null) {
+                row = session.execute(selectShardFromTaskLookupV2Statement.bind(taskUUID)).one();
+            }
+            return Optional.ofNullable(row)
                     .map(r -> String.valueOf(r.getInt(SHARD_ID_KEY)))
                     .orElse(null);
         } catch (DriverException e) {
@@ -1474,13 +1480,14 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     String lookupShardIdFromWorkflowId(String workflowId) {
         UUID workflowUUID = toUUID(workflowId, "Invalid workflow id");
         try {
-            ResultSet resultSet;
+            Row row = null;
             if (fallbackToOldWorkflowExecutionTables) {
-                resultSet = session.execute(selectShardFromWorkflowLookupStatement.bind(workflowUUID));
-            } else {
-                resultSet = session.execute(selectShardFromWorkflowLookupV2Statement.bind(workflowUUID));
+                row = session.execute(selectShardFromWorkflowLookupStatement.bind(workflowUUID)).one();
             }
-            return Optional.ofNullable(resultSet.one())
+            if (row == null) {
+                row = session.execute(selectShardFromWorkflowLookupV2Statement.bind(workflowUUID)).one();
+            }
+            return Optional.ofNullable(row)
                     .map(r -> String.valueOf(r.getInt(SHARD_ID_KEY)))
                     .orElse(null);
         } catch (DriverException e) {
@@ -1513,6 +1520,6 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         this.redisLock = applicationContext.getBean("provideRedisLock", RedisLock.class);
         setConcurrencyLimitEnabled(Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("concurrencyLimitEnabled", "false")));
         setFallbackToOldTaskInProgressActive(Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("fallbackToOldTaskInProgressActive", "false")));
-        this.fallbackToOldWorkflowExecutionTables = Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("fallbackToOldWorkflowExecutionTables", "true"));
+        this.fallbackToOldWorkflowExecutionTables = Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("fallbackToOldWorkflowExecutionTables", "false"));
     }
 }

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
@@ -92,7 +92,6 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     protected final PreparedStatement selectTotalV2Statement;
     protected final PreparedStatement selectTaskV2Statement;
     protected final PreparedStatement selectWorkflowV2Statement;
-    protected final PreparedStatement selectWorkflowWritetimeV2Statement;
     protected final PreparedStatement selectWorkflowWithTasksV2Statement;
     protected final PreparedStatement selectTaskLookupV2Statement;
     protected final PreparedStatement selectShardFromTaskLookupStatement;
@@ -250,9 +249,6 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         this.selectWorkflowV2Statement =
                 session.prepare(statements.getSelectWorkflowV2Statement())
                         .setConsistencyLevel(properties.getReadConsistencyLevel());
-        this.selectWorkflowWritetimeV2Statement =
-                session.prepare(statements.getSelectWorkflowWritetimeV2Statement())
-                        .setConsistencyLevel(properties.getWriteConsistencyLevel());
         this.selectWorkflowWithTasksStatement =
                 session.prepare(statements.getSelectWorkflowWithTasksStatement())
                         .setConsistencyLevel(properties.getReadConsistencyLevel());
@@ -877,28 +873,16 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
             try {
                 recordCassandraDaoRequests("removeWorkflow", "n/a", workflow.getWorkflowName());
 
-                // updateWorkflow uses LWT (IF version=?), which assigns a server-side Paxos
-                // timestamp that can be ahead of the client clock. A regular DELETE's
-                // client-assigned timestamp may be lower, causing the LWT-written workflow
-                // row to survive the tombstone. Query the actual write timestamp and ensure
-                // the DELETE uses a strictly higher one.
-                long lwtWriteTimestamp = queryWorkflowEntityWriteTimestamp(workflowId, correlationId);
-                long deleteTimestamp = Math.max(
-                        lwtWriteTimestamp + 1,
-                        System.currentTimeMillis() * 1000);
-
                 ResultSet oldTableResultSet = null;
                 if (fallbackToOldWorkflowExecutionTables) {
                     oldTableResultSet = session.execute(
                             deleteWorkflowStatement.bind(
-                                    UUID.fromString(workflowId), correlationId)
-                                    .setDefaultTimestamp(deleteTimestamp));
+                                    UUID.fromString(workflowId), correlationId));
                 }
                 ResultSet v2ResultSet =
                         session.execute(
                                 deleteWorkflowV2Statement.bind(
-                                        UUID.fromString(workflowId), correlationId)
-                                        .setDefaultTimestamp(deleteTimestamp));
+                                        UUID.fromString(workflowId), correlationId));
                 removed = fallbackToOldWorkflowExecutionTables ? (oldTableResultSet.wasApplied() || v2ResultSet.wasApplied()) : v2ResultSet.wasApplied();
             } catch (DriverException e) {
                 Monitors.error(CLASS_NAME, "removeWorkflow");
@@ -910,26 +894,6 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
             workflow.getTasks().forEach(this::removeTaskLookup);
         }
         return removed;
-    }
-
-    /**
-     * Queries the WRITETIME of the workflow entity row in workflows_v2.
-     * Used to determine the Paxos-assigned timestamp from LWT updates so that
-     * subsequent deletes can use a strictly higher timestamp.
-     *
-     * @return the write timestamp in microseconds, or 0 if the row does not exist
-     */
-    private long queryWorkflowEntityWriteTimestamp(String workflowId, int correlationId) {
-        try {
-            ResultSet rs = session.execute(
-                    selectWorkflowWritetimeV2Statement.bind(
-                            UUID.fromString(workflowId), correlationId));
-            Row row = rs.one();
-            return (row != null) ? row.getLong("wt") : 0;
-        } catch (Exception e) {
-            LOGGER.warn("Failed to query workflow entity write timestamp for {}", workflowId, e);
-            return 0;
-        }
     }
 
     /**

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
@@ -698,7 +698,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
                         selectTaskV2Statement.bind(
                                 UUID.fromString(workflowId), correlationId, taskId));
         Row row = resultSet.one();
-        if (row == null) {
+        if (row == null && fallbackToOldWorkflowExecutionTables) {
             resultSet =
                     session.execute(
                             selectTaskStatement.bind(
@@ -954,7 +954,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     private WorkflowModel getWorkflowModelWithTasks(String workflowId, UUID workflowUUID, Integer correlationId) {
         List<Row> rows = session.execute(
                 selectWorkflowWithTasksV2Statement.bind(workflowUUID, correlationId)).all();
-        if (rows.isEmpty() || fallbackToOldWorkflowExecutionTables) {
+        if (rows.isEmpty() && fallbackToOldWorkflowExecutionTables) {
             rows = session.execute(
                     selectWorkflowWithTasksStatement.bind(workflowUUID, correlationId)).all();
         }
@@ -992,7 +992,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     private WorkflowModel getWorkflowModelWithoutTasks(UUID workflowUUID, Integer correlationId) {
         ResultSet resultSet = session.execute(selectWorkflowV2Statement.bind(workflowUUID, correlationId));
         Row row = resultSet.one();
-        if (row == null) {
+        if (row == null && fallbackToOldWorkflowExecutionTables) {
             resultSet = session.execute(selectWorkflowStatement.bind(workflowUUID, correlationId));
             row = resultSet.one();
         }
@@ -1071,7 +1071,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
 
             List<Row> rows = session.execute(
                     selectWorkflowsByCorIdFromWorkflowV2Statement.bind(Integer.parseInt(correlationId))).all();
-            if (rows.isEmpty() || fallbackToOldWorkflowExecutionTables) {
+            if (rows.isEmpty() && fallbackToOldWorkflowExecutionTables) {
                 rows = session.execute(
                         selectWorkflowsByCorIdFromWorkflowStatement.bind(Integer.parseInt(correlationId))).all();
             }
@@ -1351,7 +1351,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         Integer corelId = Objects.isNull(correlationId) ? 0 : Integer.parseInt(correlationId);
         ResultSet resultSet = session.execute(selectTotalV2Statement.bind(UUID.fromString(workflowId), corelId));
         Row row = resultSet.one();
-        if (row == null) {
+        if (row == null && fallbackToOldWorkflowExecutionTables) {
             resultSet = session.execute(selectTotalStatement.bind(UUID.fromString(workflowId), corelId));
             row = resultSet.one();
         }
@@ -1378,7 +1378,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         try {
             ResultSet resultSet = session.execute(selectTaskLookupV2Statement.bind(taskUUID));
             Row row = resultSet.one();
-            if (row == null) {
+            if (row == null && fallbackToOldWorkflowExecutionTables) {
                 resultSet = session.execute(selectTaskLookupStatement.bind(taskUUID));
                 row = resultSet.one();
             }
@@ -1403,7 +1403,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         try {
             ResultSet resultSet = session.execute(selectShardFromTaskLookupV2Statement.bind(taskUUID));
             Row row = resultSet.one();
-            if (row == null) {
+            if (row == null && fallbackToOldWorkflowExecutionTables) {
                 resultSet = session.execute(selectShardFromTaskLookupStatement.bind(taskUUID));
                 row = resultSet.one();
             }
@@ -1428,7 +1428,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         try {
             ResultSet resultSet = session.execute(selectShardFromWorkflowLookupV2Statement.bind(workflowUUID));
             Row row = resultSet.one();
-            if (row == null) {
+            if (row == null && fallbackToOldWorkflowExecutionTables) {
                 resultSet = session.execute(selectShardFromWorkflowLookupStatement.bind(workflowUUID));
                 row = resultSet.one();
             }

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
@@ -72,7 +72,9 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     private static final String CLASS_NAME = ScyllaExecutionDAO.class.getSimpleName();
 
     protected final PreparedStatement insertWorkflowStatement;
+    protected final PreparedStatement insertWorkflowV2Statement;
     protected final PreparedStatement insertTaskStatement;
+    protected final PreparedStatement insertTaskV2Statement;
     protected final PreparedStatement insertEventExecutionStatement;
     protected final PreparedStatement insertTaskInProgressStatement;
     protected final PreparedStatement insertTaskInProgressV2Statement;
@@ -87,13 +89,23 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     protected final PreparedStatement selectWorkflowStatement;
     protected final PreparedStatement selectWorkflowWithTasksStatement;
     protected final PreparedStatement selectTaskLookupStatement;
+    protected final PreparedStatement selectTotalV2Statement;
+    protected final PreparedStatement selectTaskV2Statement;
+    protected final PreparedStatement selectWorkflowV2Statement;
+    protected final PreparedStatement selectWorkflowWithTasksV2Statement;
+    protected final PreparedStatement selectTaskLookupV2Statement;
     protected final PreparedStatement selectShardFromTaskLookupStatement;
+    protected final PreparedStatement selectShardFromTaskLookupV2Statement;
 
     protected final PreparedStatement selectWorkflowsByCorIdFromWorkflowStatement;
+    protected final PreparedStatement selectWorkflowsByCorIdFromWorkflowV2Statement;
 
     protected final PreparedStatement selectShardFromWorkflowLookupStatement;
     protected final PreparedStatement updateWorkflowLookupStatement;
     protected final PreparedStatement deleteWorkflowLookupStatement;
+    protected final PreparedStatement selectShardFromWorkflowLookupV2Statement;
+    protected final PreparedStatement updateWorkflowLookupV2Statement;
+    protected final PreparedStatement deleteWorkflowLookupV2Statement;
     protected final PreparedStatement selectTasksFromTaskDefLimitStatement;
     protected final PreparedStatement selectEventExecutionsStatement;
 
@@ -101,12 +113,19 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     protected final PreparedStatement updateTotalTasksStatement;
     protected final PreparedStatement updateTotalPartitionsStatement;
     protected final PreparedStatement updateTaskLookupStatement;
+    protected final PreparedStatement updateWorkflowV2Statement;
+    protected final PreparedStatement updateTotalTasksV2Statement;
+    protected final PreparedStatement updateTotalPartitionsV2Statement;
+    protected final PreparedStatement updateTaskLookupV2Statement;
     protected final PreparedStatement updateTaskDefLimitStatement;
     protected final PreparedStatement updateEventExecutionStatement;
 
     protected final PreparedStatement deleteWorkflowStatement;
     protected final PreparedStatement deleteTaskStatement;
     protected final PreparedStatement deleteTaskLookupStatement;
+    protected final PreparedStatement deleteWorkflowV2Statement;
+    protected final PreparedStatement deleteTaskV2Statement;
+    protected final PreparedStatement deleteTaskLookupV2Statement;
     protected final PreparedStatement deleteTaskDefLimitStatement;
     protected final PreparedStatement deleteEventExecutionStatement;
 
@@ -115,6 +134,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
 
     private boolean isConcurrencyLimitEnabled;
     private boolean fallbackToOldTaskInProgressActive;
+    private boolean fallbackToOldWorkflowExecutionTables;
 
     public ScyllaExecutionDAO(
             Session session,
@@ -128,8 +148,14 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         this.insertWorkflowStatement =
                 session.prepare(statements.getInsertWorkflowStatement())
                         .setConsistencyLevel(properties.getWriteConsistencyLevel());
+        this.insertWorkflowV2Statement =
+                session.prepare(statements.getInsertWorkflowV2Statement())
+                        .setConsistencyLevel(properties.getWriteConsistencyLevel());
         this.insertTaskStatement =
                 session.prepare(statements.getInsertTaskStatement())
+                        .setConsistencyLevel(properties.getWriteConsistencyLevel());
+        this.insertTaskV2Statement =
+                session.prepare(statements.getInsertTaskV2Statement())
                         .setConsistencyLevel(properties.getWriteConsistencyLevel());
         this.insertEventExecutionStatement =
                 session.prepare(statements.getInsertEventExecutionStatement())
@@ -153,21 +179,40 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         this.selectShardFromTaskLookupStatement =
                 session.prepare(statements.getSelectShardFromTaskLookupTableStatement())
                         .setConsistencyLevel(properties.getReadConsistencyLevel());
+        this.selectShardFromTaskLookupV2Statement =
+                session.prepare(statements.getSelectShardFromTaskLookupTableV2Statement())
+                        .setConsistencyLevel(properties.getReadConsistencyLevel());
 
         this.selectWorkflowsByCorIdFromWorkflowStatement =
                 session.prepare(statements.getSelectWorkflowsByCorrelationIdStatement())
+                        .setConsistencyLevel(properties.getReadConsistencyLevel());
+
+        this.selectWorkflowsByCorIdFromWorkflowV2Statement =
+                session.prepare(statements.getSelectWorkflowsByCorrelationIdV2Statement())
                         .setConsistencyLevel(properties.getReadConsistencyLevel());
 
         this.selectShardFromWorkflowLookupStatement =
                 session.prepare(statements.getSelectShardFromWorkflowLookupTableStatement())
                         .setConsistencyLevel(properties.getReadConsistencyLevel());
 
+        this.selectShardFromWorkflowLookupV2Statement =
+                session.prepare(statements.getSelectShardFromWorkflowLookupTableV2Statement())
+                        .setConsistencyLevel(properties.getReadConsistencyLevel());
+
         this.updateWorkflowLookupStatement =
                 session.prepare(statements.getUpdateWorkflowLookupStatement())
                         .setConsistencyLevel(properties.getReadConsistencyLevel());
 
+        this.updateWorkflowLookupV2Statement =
+                session.prepare(statements.getUpdateWorkflowLookupV2Statement())
+                        .setConsistencyLevel(properties.getReadConsistencyLevel());
+
         this.deleteWorkflowLookupStatement =
                 session.prepare(statements.getDeleteWorkflowLookupStatement())
+                        .setConsistencyLevel(properties.getReadConsistencyLevel());
+
+        this.deleteWorkflowLookupV2Statement =
+                session.prepare(statements.getDeleteWorkflowLookupV2Statement())
                         .setConsistencyLevel(properties.getReadConsistencyLevel());
 
         this.updateTaskInProgressStatement =
@@ -189,17 +234,32 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         this.selectTotalStatement =
                 session.prepare(statements.getSelectTotalStatement())
                         .setConsistencyLevel(properties.getReadConsistencyLevel());
+        this.selectTotalV2Statement =
+                session.prepare(statements.getSelectTotalV2Statement())
+                        .setConsistencyLevel(properties.getReadConsistencyLevel());
         this.selectTaskStatement =
                 session.prepare(statements.getSelectTaskStatement())
+                        .setConsistencyLevel(properties.getReadConsistencyLevel());
+        this.selectTaskV2Statement =
+                session.prepare(statements.getSelectTaskV2Statement())
                         .setConsistencyLevel(properties.getReadConsistencyLevel());
         this.selectWorkflowStatement =
                 session.prepare(statements.getSelectWorkflowStatement())
                         .setConsistencyLevel(properties.getReadConsistencyLevel());
+        this.selectWorkflowV2Statement =
+                session.prepare(statements.getSelectWorkflowV2Statement())
+                        .setConsistencyLevel(properties.getReadConsistencyLevel());
         this.selectWorkflowWithTasksStatement =
                 session.prepare(statements.getSelectWorkflowWithTasksStatement())
                         .setConsistencyLevel(properties.getReadConsistencyLevel());
+        this.selectWorkflowWithTasksV2Statement =
+                session.prepare(statements.getSelectWorkflowWithTasksV2Statement())
+                        .setConsistencyLevel(properties.getReadConsistencyLevel());
         this.selectTaskLookupStatement =
                 session.prepare(statements.getSelectTaskFromLookupTableStatement())
+                        .setConsistencyLevel(properties.getReadConsistencyLevel());
+        this.selectTaskLookupV2Statement =
+                session.prepare(statements.getSelectTaskFromLookupTableV2Statement())
                         .setConsistencyLevel(properties.getReadConsistencyLevel());
         this.selectTasksFromTaskDefLimitStatement =
                 session.prepare(statements.getSelectTasksFromTaskDefLimitStatement())
@@ -212,14 +272,26 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         this.updateWorkflowStatement =
                 session.prepare(statements.getUpdateWorkflowStatement())
                         .setConsistencyLevel(properties.getWriteConsistencyLevel());
+        this.updateWorkflowV2Statement =
+                session.prepare(statements.getUpdateWorkflowV2Statement())
+                        .setConsistencyLevel(properties.getWriteConsistencyLevel());
         this.updateTotalTasksStatement =
                 session.prepare(statements.getUpdateTotalTasksStatement())
+                        .setConsistencyLevel(properties.getWriteConsistencyLevel());
+        this.updateTotalTasksV2Statement =
+                session.prepare(statements.getUpdateTotalTasksV2Statement())
                         .setConsistencyLevel(properties.getWriteConsistencyLevel());
         this.updateTotalPartitionsStatement =
                 session.prepare(statements.getUpdateTotalPartitionsStatement())
                         .setConsistencyLevel(properties.getWriteConsistencyLevel());
+        this.updateTotalPartitionsV2Statement =
+                session.prepare(statements.getUpdateTotalPartitionsV2Statement())
+                        .setConsistencyLevel(properties.getWriteConsistencyLevel());
         this.updateTaskLookupStatement =
                 session.prepare(statements.getUpdateTaskLookupStatement())
+                        .setConsistencyLevel(properties.getWriteConsistencyLevel());
+        this.updateTaskLookupV2Statement =
+                session.prepare(statements.getUpdateTaskLookupV2Statement())
                         .setConsistencyLevel(properties.getWriteConsistencyLevel());
         this.updateTaskDefLimitStatement =
                 session.prepare(statements.getUpdateTaskDefLimitStatement())
@@ -231,11 +303,20 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         this.deleteWorkflowStatement =
                 session.prepare(statements.getDeleteWorkflowStatement())
                         .setConsistencyLevel(properties.getWriteConsistencyLevel());
+        this.deleteWorkflowV2Statement =
+                session.prepare(statements.getDeleteWorkflowV2Statement())
+                        .setConsistencyLevel(properties.getWriteConsistencyLevel());
         this.deleteTaskStatement =
                 session.prepare(statements.getDeleteTaskStatement())
                         .setConsistencyLevel(properties.getWriteConsistencyLevel());
+        this.deleteTaskV2Statement =
+                session.prepare(statements.getDeleteTaskV2Statement())
+                        .setConsistencyLevel(properties.getWriteConsistencyLevel());
         this.deleteTaskLookupStatement =
                 session.prepare(statements.getDeleteTaskLookupStatement())
+                        .setConsistencyLevel(properties.getWriteConsistencyLevel());
+        this.deleteTaskLookupV2Statement =
+                session.prepare(statements.getDeleteTaskLookupV2Statement())
                         .setConsistencyLevel(properties.getWriteConsistencyLevel());
         this.deleteTaskDefLimitStatement =
                 session.prepare(statements.getDeleteTaskDefLimitStatement())
@@ -291,9 +372,15 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
                             task.setScheduledTime(System.currentTimeMillis());
                         }
                         BatchStatement batchStatement = new BatchStatement(BatchStatement.Type.UNLOGGED);
-                        batchStatement.add(updateTaskLookupStatement.bind(
+                        if (fallbackToOldWorkflowExecutionTables) {
+                            batchStatement.add(updateTaskLookupStatement.bind(
+                                    workflowUUID, correlationId, toUUID(task.getTaskId(), "Invalid task id")));
+                            batchStatement.add(updateWorkflowLookupStatement.bind(
+                                    correlationId, workflowUUID));
+                        }
+                        batchStatement.add(updateTaskLookupV2Statement.bind(
                                 workflowUUID, correlationId, toUUID(task.getTaskId(), "Invalid task id")));
-                        batchStatement.add(updateWorkflowLookupStatement.bind(
+                        batchStatement.add(updateWorkflowLookupV2Statement.bind(
                                 correlationId, workflowUUID));
                         session.execute(batchStatement);
                         // Added the task to task_in_progress table
@@ -305,13 +392,20 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
             tasks.forEach(
                     task -> {
                         String taskPayload = toJson(task);
+                        if (fallbackToOldWorkflowExecutionTables) {
+                            batchStatement.add(
+                                    insertTaskStatement.bind(
+                                            workflowUUID,
+                                            correlationId,
+                                            task.getTaskId(),
+                                            taskPayload));
+                        }
                         batchStatement.add(
-                                insertTaskStatement.bind(
+                                insertTaskV2Statement.bind(
                                         workflowUUID,
                                         correlationId,
                                         task.getTaskId(),
                                         taskPayload));
-
                         recordCassandraDaoRequests(
                                 "createTask", task.getTaskType(), task.getWorkflowType());
 
@@ -323,12 +417,20 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
 
 
                     });
+            if (fallbackToOldWorkflowExecutionTables) {
+                batchStatement.add(
+                        updateTotalTasksStatement.bind(totalTasks, workflowUUID, correlationId));
+            }
             batchStatement.add(
-                    updateTotalTasksStatement.bind(totalTasks, workflowUUID, correlationId));
+                    updateTotalTasksV2Statement.bind(totalTasks, workflowUUID, correlationId));
             session.execute(batchStatement);
-            // update the total tasks and partitions for the workflow
+            if (fallbackToOldWorkflowExecutionTables) {
+                session.execute(
+                        updateTotalPartitionsStatement.bind(
+                                DEFAULT_TOTAL_PARTITIONS, totalTasks, workflowUUID, correlationId));
+            }
             session.execute(
-                    updateTotalPartitionsStatement.bind(
+                    updateTotalPartitionsV2Statement.bind(
                             DEFAULT_TOTAL_PARTITIONS, totalTasks, workflowUUID, correlationId));
 
             return tasks;
@@ -440,12 +542,20 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
                         prevTask.getStatus());
 
                 if (!prevTask.getStatus().equals(TaskModel.Status.COMPLETED)) {**/
+                if (fallbackToOldWorkflowExecutionTables) {
                     session.execute(
                             insertTaskStatement.bind(
                                     UUID.fromString(task.getWorkflowInstanceId()),
                                     correlationId,
                                     task.getTaskId(),
                                     taskPayload));
+                }
+                session.execute(
+                        insertTaskV2Statement.bind(
+                                UUID.fromString(task.getWorkflowInstanceId()),
+                                correlationId,
+                                task.getTaskId(),
+                                taskPayload));
                     LOGGER.debug("Updated updateTask for task {} with taskStatus {}  with taskRefName {} for workflowId {} ",
                             task.getTaskId(), task.getStatus(), task.getReferenceTaskName(), task.getWorkflowInstanceId());
                 //}
@@ -585,12 +695,20 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
 
         ResultSet resultSet =
                 session.execute(
-                        selectTaskStatement.bind(
+                        selectTaskV2Statement.bind(
                                 UUID.fromString(workflowId), correlationId, taskId));
-        return Optional.ofNullable(resultSet.one())
+        Row row = resultSet.one();
+        if (row == null) {
+            resultSet =
+                    session.execute(
+                            selectTaskStatement.bind(
+                                    UUID.fromString(workflowId), correlationId, taskId));
+            row = resultSet.one();
+        }
+        return Optional.ofNullable(row)
                 .map(
-                        row -> {
-                            String taskRow = row.getString(PAYLOAD_KEY);
+                        currentRow -> {
+                            String taskRow = currentRow.getString(PAYLOAD_KEY);
                             TaskModel task = readValue(taskRow, TaskModel.class);
                             recordCassandraDaoRequests(
                                     "getTask", task.getTaskType(), task.getWorkflowType());
@@ -646,9 +764,14 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
             recordCassandraDaoRequests("createWorkflow", "n/a", workflow.getWorkflowName());
             recordCassandraDaoPayloadSize(
                     "createWorkflow", payload.length(), "n/a", workflow.getWorkflowName());
+            if (fallbackToOldWorkflowExecutionTables) {
+                session.execute(
+                        insertWorkflowStatement.bind(
+                                UUID.fromString(workflow.getWorkflowId()), correlationId, "", payload, 0, 1, 1));
+            }
             session.execute(
-                    insertWorkflowStatement.bind(
-                            UUID.fromString(workflow.getWorkflowId()), correlationId, "", payload, 0, 1,1));
+                    insertWorkflowV2Statement.bind(
+                            UUID.fromString(workflow.getWorkflowId()), correlationId, "", payload, 0, 1, 1));
 
             workflow.setTasks(tasks);
             return workflow.getWorkflowId();
@@ -694,9 +817,18 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
 
     private boolean attemptUpdateWorkflow(WorkflowModel workflow, WorkflowModel prevWorkflow,  String payload, Integer correlationId, Boolean isRetry) {
         Integer currentVersion = prevWorkflow.getVersion() == 0 ? null : prevWorkflow.getVersion();
-        ResultSet resultSet = session.execute(updateWorkflowStatement.bind(payload, prevWorkflow.getVersion() + 1,
+        ResultSet oldTableResultSet = null;
+
+        if (fallbackToOldWorkflowExecutionTables) {
+            oldTableResultSet = session.execute(updateWorkflowStatement.bind(payload, prevWorkflow.getVersion() + 1,
+                    UUID.fromString(workflow.getWorkflowId()), correlationId, currentVersion));
+        }
+        ResultSet v2ResultSet = session.execute(updateWorkflowV2Statement.bind(payload, prevWorkflow.getVersion() + 1,
                 UUID.fromString(workflow.getWorkflowId()), correlationId, currentVersion));
-        if (resultSet.wasApplied()) {
+
+        boolean wasWorkflowUpdateApplied =
+                fallbackToOldWorkflowExecutionTables ? oldTableResultSet.wasApplied() : v2ResultSet.wasApplied();
+        if (wasWorkflowUpdateApplied) {
             LOGGER.debug("Updated workflow with isRetry {} - current status {} for workflowId {} with version {}",
                     isRetry, workflow.getStatus(), workflow.getWorkflowId(), prevWorkflow.getVersion() + 1);
             return true;
@@ -734,11 +866,17 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         if (workflow != null) {
             try {
                 recordCassandraDaoRequests("removeWorkflow", "n/a", workflow.getWorkflowName());
-                ResultSet resultSet =
+                ResultSet oldTableResultSet = null;
+                if (fallbackToOldWorkflowExecutionTables) {
+                    oldTableResultSet = session.execute(
+                            deleteWorkflowStatement.bind(
+                                    UUID.fromString(workflowId), correlationId));
+                }
+                ResultSet v2ResultSet =
                         session.execute(
-                                deleteWorkflowStatement.bind(
+                                deleteWorkflowV2Statement.bind(
                                         UUID.fromString(workflowId), correlationId));
-                removed = resultSet.wasApplied();
+                removed = fallbackToOldWorkflowExecutionTables ? oldTableResultSet.wasApplied() : v2ResultSet.wasApplied();
             } catch (DriverException e) {
                 Monitors.error(CLASS_NAME, "removeWorkflow");
                 logErrorToDebug(Thread.currentThread().getStackTrace()[2].getMethodName(), e);
@@ -799,61 +937,11 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
 
     private WorkflowModel getWorkflowModel(String workflowId, boolean includeTasks, UUID workflowUUID, Integer correlationId) {
         try {
-            WorkflowModel workflow = null;
-            ResultSet resultSet;
             if (includeTasks) {
-                resultSet =
-                        session.execute(
-                                selectWorkflowWithTasksStatement.bind(
-                                        workflowUUID, correlationId));
-                List<TaskModel> tasks = new ArrayList<>();
-
-                List<Row> rows = resultSet.all();
-                if (rows.size() == 0) {
-                    LOGGER.info("Workflow {} not found in datastore", workflowId);
-                    return null;
-                }
-                for (Row row : rows) {
-                    String entityKey = row.getString(ENTITY_KEY);
-                    if (ENTITY_TYPE_WORKFLOW.equals(entityKey)) {
-                        workflow = readValue(row.getString(PAYLOAD_KEY), WorkflowModel.class);
-                        // Added version for version locking
-                        workflow.setVersion(row.getInt(VERSION));
-                    } else if (ENTITY_TYPE_TASK.equals(entityKey)) {
-                        TaskModel task = readValue(row.getString(PAYLOAD_KEY), TaskModel.class);
-                        tasks.add(task);
-                    } else {
-                        throw new NonTransientException(
-                                String.format(
-                                        "Invalid row with entityKey: %s found in datastore for workflow: %s",
-                                        entityKey, workflowId));
-                    }
-                }
-
-                if (workflow != null) {
-                    recordCassandraDaoRequests("getWorkflow", "n/a", workflow.getWorkflowName());
-                    tasks.sort(Comparator.comparingInt(TaskModel::getSeq));
-                    workflow.setTasks(tasks);
-                }
+                return getWorkflowModelWithTasks(workflowId, workflowUUID, correlationId);
             } else {
-                resultSet = session.execute(selectWorkflowStatement.bind(workflowUUID, correlationId));
-                workflow =
-                        Optional.ofNullable(resultSet.one())
-                                .map(
-                                        row -> {
-                                            WorkflowModel wf =
-                                                    readValue(
-                                                            row.getString(PAYLOAD_KEY),
-                                                            WorkflowModel.class);
-                                            // Added version for version locking
-                                            wf.setVersion(row.getInt(VERSION));
-                                            recordCassandraDaoRequests(
-                                                    "getWorkflow", "n/a", wf.getWorkflowName());
-                                            return wf;
-                                        })
-                                .orElse(null);
+                return getWorkflowModelWithoutTasks(workflowUUID, correlationId);
             }
-            return workflow;
         } catch (DriverException e) {
             Monitors.error(CLASS_NAME, "getWorkflow");
             logErrorToDebug(Thread.currentThread().getStackTrace()[2].getMethodName(), e);
@@ -861,6 +949,66 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
             LOGGER.error(errorMsg, e);
             throw new TransientException(errorMsg);
         }
+    }
+
+    private WorkflowModel getWorkflowModelWithTasks(String workflowId, UUID workflowUUID, Integer correlationId) {
+        List<Row> rows = session.execute(
+                selectWorkflowWithTasksV2Statement.bind(workflowUUID, correlationId)).all();
+        if (rows.isEmpty() || fallbackToOldWorkflowExecutionTables) {
+            rows = session.execute(
+                    selectWorkflowWithTasksStatement.bind(workflowUUID, correlationId)).all();
+        }
+        if (rows.isEmpty()) {
+            LOGGER.info("Workflow {} not found in datastore", workflowId);
+            return null;
+        }
+
+        WorkflowModel workflow = null;
+        List<TaskModel> tasks = new ArrayList<>();
+        for (Row row : rows) {
+            String entityKey = row.getString(ENTITY_KEY);
+            if (ENTITY_TYPE_WORKFLOW.equals(entityKey)) {
+                workflow = readValue(row.getString(PAYLOAD_KEY), WorkflowModel.class);
+                workflow.setVersion(row.getInt(VERSION));
+            } else if (ENTITY_TYPE_TASK.equals(entityKey)) {
+                TaskModel task = readValue(row.getString(PAYLOAD_KEY), TaskModel.class);
+                tasks.add(task);
+            } else {
+                throw new NonTransientException(
+                        String.format(
+                                "Invalid row with entityKey: %s found in datastore for workflow: %s",
+                                entityKey, workflowId));
+            }
+        }
+
+        if (workflow != null) {
+            recordCassandraDaoRequests("getWorkflow", "n/a", workflow.getWorkflowName());
+            tasks.sort(Comparator.comparingInt(TaskModel::getSeq));
+            workflow.setTasks(tasks);
+        }
+        return workflow;
+    }
+
+    private WorkflowModel getWorkflowModelWithoutTasks(UUID workflowUUID, Integer correlationId) {
+        ResultSet resultSet = session.execute(selectWorkflowV2Statement.bind(workflowUUID, correlationId));
+        Row row = resultSet.one();
+        if (row == null) {
+            resultSet = session.execute(selectWorkflowStatement.bind(workflowUUID, correlationId));
+            row = resultSet.one();
+        }
+        return Optional.ofNullable(row)
+                .map(
+                        r -> {
+                            WorkflowModel wf =
+                                    readValue(
+                                            r.getString(PAYLOAD_KEY),
+                                            WorkflowModel.class);
+                            wf.setVersion(r.getInt(VERSION));
+                            recordCassandraDaoRequests(
+                                    "getWorkflow", "n/a", wf.getWorkflowName());
+                            return wf;
+                        })
+                .orElse(null);
     }
 
     /**
@@ -921,8 +1069,13 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         try{
             recordCassandraDaoRequests("getWorkflowsByCorrelationId", "n/a", correlationId);
 
-            ResultSet resultSet = session.execute(selectWorkflowsByCorIdFromWorkflowStatement.bind(Integer.parseInt(correlationId)));
-            List<WorkflowModel> wfList = resultSet.all().stream()
+            List<Row> rows = session.execute(
+                    selectWorkflowsByCorIdFromWorkflowV2Statement.bind(Integer.parseInt(correlationId))).all();
+            if (rows.isEmpty() || fallbackToOldWorkflowExecutionTables) {
+                rows = session.execute(
+                        selectWorkflowsByCorIdFromWorkflowStatement.bind(Integer.parseInt(correlationId))).all();
+            }
+            List<WorkflowModel> wfList = rows.stream()
                     .map(row -> {
                         WorkflowModel wf =
                                 readValue(
@@ -1107,15 +1260,26 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
             removeTaskInProgress(task);
 
             recordCassandraDaoRequests("removeTask", task.getTaskType(), task.getWorkflowType());
-            // delete task from workflows table and decrement total tasks by 1
             BatchStatement batchStatement = new BatchStatement(BatchStatement.Type.UNLOGGED);
+            if (fallbackToOldWorkflowExecutionTables) {
+                batchStatement.add(
+                        deleteTaskStatement.bind(
+                                UUID.fromString(task.getWorkflowInstanceId()),
+                                correlationId,
+                                task.getTaskId()));
+                batchStatement.add(
+                        updateTotalTasksStatement.bind(
+                                totalTasks - 1,
+                                UUID.fromString(task.getWorkflowInstanceId()),
+                                correlationId));
+            }
             batchStatement.add(
-                    deleteTaskStatement.bind(
+                    deleteTaskV2Statement.bind(
                             UUID.fromString(task.getWorkflowInstanceId()),
                             correlationId,
                             task.getTaskId()));
             batchStatement.add(
-                    updateTotalTasksStatement.bind(
+                    updateTotalTasksV2Statement.bind(
                             totalTasks - 1,
                             UUID.fromString(task.getWorkflowInstanceId()),
                             correlationId));
@@ -1142,8 +1306,12 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
                     && task.getTaskDefinition().get().concurrencyLimit() > 0) {
                 removeTaskFromLimit(task);
             }
-            session.execute(deleteTaskLookupStatement.bind(UUID.fromString(task.getTaskId())));
-            session.execute(deleteWorkflowLookupStatement.bind(UUID.fromString(task.getWorkflowInstanceId())));
+            if (fallbackToOldWorkflowExecutionTables) {
+                session.execute(deleteTaskLookupStatement.bind(UUID.fromString(task.getTaskId())));
+                session.execute(deleteWorkflowLookupStatement.bind(UUID.fromString(task.getWorkflowInstanceId())));
+            }
+            session.execute(deleteTaskLookupV2Statement.bind(UUID.fromString(task.getTaskId())));
+            session.execute(deleteWorkflowLookupV2Statement.bind(UUID.fromString(task.getWorkflowInstanceId())));
         } catch (DriverException e) {
             Monitors.error(CLASS_NAME, "removeTaskLookup");
             logErrorToDebug(Thread.currentThread().getStackTrace()[2].getMethodName(), e);
@@ -1181,15 +1349,20 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     @VisibleForTesting
     WorkflowMetadata getWorkflowMetadata(String workflowId, String correlationId) {
         Integer corelId = Objects.isNull(correlationId) ? 0 : Integer.parseInt(correlationId);
-        ResultSet resultSet =
-                session.execute(selectTotalStatement.bind(UUID.fromString(workflowId),corelId));
+        ResultSet resultSet = session.execute(selectTotalV2Statement.bind(UUID.fromString(workflowId), corelId));
+        Row row = resultSet.one();
+        if (row == null) {
+            resultSet = session.execute(selectTotalStatement.bind(UUID.fromString(workflowId), corelId));
+            row = resultSet.one();
+        }
         recordCassandraDaoRequests("getWorkflowMetadata");
-        return Optional.ofNullable(resultSet.one())
+
+        return Optional.ofNullable(row)
                 .map(
-                        row -> {
+                        currentRow -> {
                             WorkflowMetadata workflowMetadata = new WorkflowMetadata();
-                            workflowMetadata.setTotalTasks(row.getInt(TOTAL_TASKS_KEY));
-                            workflowMetadata.setTotalPartitions(row.getInt(TOTAL_PARTITIONS_KEY));
+                            workflowMetadata.setTotalTasks(currentRow.getInt(TOTAL_TASKS_KEY));
+                            workflowMetadata.setTotalPartitions(currentRow.getInt(TOTAL_PARTITIONS_KEY));
                             return workflowMetadata;
                         })
                 .orElseThrow(
@@ -1203,9 +1376,14 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     String lookupWorkflowIdFromTaskId(String taskId) {
         UUID taskUUID = toUUID(taskId, "Invalid task id");
         try {
-            ResultSet resultSet = session.execute(selectTaskLookupStatement.bind(taskUUID));
-            return Optional.ofNullable(resultSet.one())
-                    .map(row -> row.getUUID(WORKFLOW_ID_KEY).toString())
+            ResultSet resultSet = session.execute(selectTaskLookupV2Statement.bind(taskUUID));
+            Row row = resultSet.one();
+            if (row == null) {
+                resultSet = session.execute(selectTaskLookupStatement.bind(taskUUID));
+                row = resultSet.one();
+            }
+            return Optional.ofNullable(row)
+                    .map(r -> r.getUUID(WORKFLOW_ID_KEY).toString())
                     .orElse(null);
         } catch (DriverException e) {
             Monitors.error(CLASS_NAME, "lookupWorkflowIdFromTaskId");
@@ -1223,9 +1401,14 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     String lookupShardIdFromTaskId(String taskId) {
         UUID taskUUID = toUUID(taskId, "Invalid task id");
         try {
-            ResultSet resultSet = session.execute(selectShardFromTaskLookupStatement.bind(taskUUID));
-            return Optional.ofNullable(resultSet.one())
-                    .map(row -> String.valueOf(row.getInt(SHARD_ID_KEY)))
+            ResultSet resultSet = session.execute(selectShardFromTaskLookupV2Statement.bind(taskUUID));
+            Row row = resultSet.one();
+            if (row == null) {
+                resultSet = session.execute(selectShardFromTaskLookupStatement.bind(taskUUID));
+                row = resultSet.one();
+            }
+            return Optional.ofNullable(row)
+                    .map(r -> String.valueOf(r.getInt(SHARD_ID_KEY)))
                     .orElse(null);
         } catch (DriverException e) {
             Monitors.error(CLASS_NAME, "lookupShardIdFromTaskId");
@@ -1243,12 +1426,14 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     String lookupShardIdFromWorkflowId(String workflowId) {
         UUID workflowUUID = toUUID(workflowId, "Invalid workflow id");
         try {
-            ResultSet resultSet = session.execute(selectShardFromWorkflowLookupStatement.bind(workflowUUID));
-
-            return Optional.ofNullable(resultSet.one())
-                    .map(row -> {
-                        return String.valueOf(row.getInt(SHARD_ID_KEY));
-                    })
+            ResultSet resultSet = session.execute(selectShardFromWorkflowLookupV2Statement.bind(workflowUUID));
+            Row row = resultSet.one();
+            if (row == null) {
+                resultSet = session.execute(selectShardFromWorkflowLookupStatement.bind(workflowUUID));
+                row = resultSet.one();
+            }
+            return Optional.ofNullable(row)
+                    .map(r -> String.valueOf(r.getInt(SHARD_ID_KEY)))
                     .orElse(null);
         } catch (DriverException e) {
             Monitors.error(CLASS_NAME, "lookupShardIdFromWorkflowId");
@@ -1280,5 +1465,6 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         this.redisLock = (RedisLock) applicationContext.getBean("provideRedisLock");
         setConcurrencyLimitEnabled(Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("concurrencyLimitEnabled", "false")));
         setFallbackToOldTaskInProgressActive(Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("fallbackToOldTaskInProgressActive", "false")));
+        this.fallbackToOldWorkflowExecutionTables = Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("fallbackToOldWorkflowExecutionTables", "false"));
     }
 }

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
@@ -372,6 +372,12 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
                             task.setScheduledTime(System.currentTimeMillis());
                         }
                         BatchStatement batchStatement = new BatchStatement(BatchStatement.Type.UNLOGGED);
+                        if (fallbackToOldWorkflowExecutionTables) {
+                            batchStatement.add(updateTaskLookupStatement.bind(
+                                    workflowUUID, correlationId, toUUID(task.getTaskId(), "Invalid task id")));
+                            batchStatement.add(updateWorkflowLookupStatement.bind(
+                                    correlationId, workflowUUID));
+                        }
                         batchStatement.add(updateTaskLookupV2Statement.bind(
                                 workflowUUID, correlationId, toUUID(task.getTaskId(), "Invalid task id")));
                         batchStatement.add(updateWorkflowLookupV2Statement.bind(
@@ -386,6 +392,14 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
             tasks.forEach(
                     task -> {
                         String taskPayload = toJson(task);
+                        if (fallbackToOldWorkflowExecutionTables) {
+                            batchStatement.add(
+                                    insertTaskStatement.bind(
+                                            workflowUUID,
+                                            correlationId,
+                                            task.getTaskId(),
+                                            taskPayload));
+                        }
                         batchStatement.add(
                                 insertTaskV2Statement.bind(
                                         workflowUUID,
@@ -528,6 +542,14 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
                         prevTask.getStatus());
 
                 if (!prevTask.getStatus().equals(TaskModel.Status.COMPLETED)) {**/
+                if (fallbackToOldWorkflowExecutionTables) {
+                    session.execute(
+                            insertTaskStatement.bind(
+                                    UUID.fromString(task.getWorkflowInstanceId()),
+                                    correlationId,
+                                    task.getTaskId(),
+                                    taskPayload));
+                }
                 session.execute(
                         insertTaskV2Statement.bind(
                                 UUID.fromString(task.getWorkflowInstanceId()),
@@ -742,6 +764,11 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
             recordCassandraDaoRequests("createWorkflow", "n/a", workflow.getWorkflowName());
             recordCassandraDaoPayloadSize(
                     "createWorkflow", payload.length(), "n/a", workflow.getWorkflowName());
+            if(fallbackToOldWorkflowExecutionTables) {
+                session.execute(
+                        insertWorkflowStatement.bind(
+                                UUID.fromString(workflow.getWorkflowId()), correlationId, "", payload, 0, 1, 1));
+            }
             session.execute(
                     insertWorkflowV2Statement.bind(
                             UUID.fromString(workflow.getWorkflowId()), correlationId, "", payload, 0, 1, 1));
@@ -966,11 +993,13 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     }
 
     private WorkflowModel getWorkflowModelWithTasks(String workflowId, UUID workflowUUID, Integer correlationId) {
-        List<Row> rows = session.execute(
-                selectWorkflowWithTasksV2Statement.bind(workflowUUID, correlationId)).all();
-        if (rows.isEmpty() && fallbackToOldWorkflowExecutionTables) {
+        List<Row> rows;
+        if (fallbackToOldWorkflowExecutionTables) {
             rows = session.execute(
                     selectWorkflowWithTasksStatement.bind(workflowUUID, correlationId)).all();
+        } else {
+            rows = session.execute(
+                    selectWorkflowWithTasksV2Statement.bind(workflowUUID, correlationId)).all();
         }
         if (rows.isEmpty()) {
             LOGGER.info("Workflow {} not found in datastore", workflowId);
@@ -1004,13 +1033,13 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     }
 
     private WorkflowModel getWorkflowModelWithoutTasks(UUID workflowUUID, Integer correlationId) {
-        ResultSet resultSet = session.execute(selectWorkflowV2Statement.bind(workflowUUID, correlationId));
-        Row row = resultSet.one();
-        if (row == null && fallbackToOldWorkflowExecutionTables) {
-            resultSet = session.execute(selectWorkflowStatement.bind(workflowUUID, correlationId));
-            row = resultSet.one();
+        ResultSet resultSet;
+        if (fallbackToOldWorkflowExecutionTables) {
+            resultSet = session.execute(selectWorkflowStatement.bind(workflowUUID, correlationId));;
+        } else {
+            resultSet = session.execute(selectWorkflowV2Statement.bind(workflowUUID, correlationId));;
         }
-        return Optional.ofNullable(row)
+        return Optional.ofNullable(resultSet.one())
                 .map(
                         r -> {
                             WorkflowModel wf =
@@ -1083,11 +1112,13 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         try{
             recordCassandraDaoRequests("getWorkflowsByCorrelationId", "n/a", correlationId);
 
-            List<Row> rows = session.execute(
-                    selectWorkflowsByCorIdFromWorkflowV2Statement.bind(Integer.parseInt(correlationId))).all();
-            if (rows.isEmpty() && fallbackToOldWorkflowExecutionTables) {
+            List<Row> rows;
+            if (fallbackToOldWorkflowExecutionTables) {
                 rows = session.execute(
                         selectWorkflowsByCorIdFromWorkflowStatement.bind(Integer.parseInt(correlationId))).all();
+            } else {
+                rows = session.execute(
+                        selectWorkflowsByCorIdFromWorkflowV2Statement.bind(Integer.parseInt(correlationId))).all();
             }
             List<WorkflowModel> wfList = rows.stream()
                     .map(row -> {
@@ -1363,15 +1394,16 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     @VisibleForTesting
     WorkflowMetadata getWorkflowMetadata(String workflowId, String correlationId) {
         Integer corelId = Objects.isNull(correlationId) ? 0 : Integer.parseInt(correlationId);
-        ResultSet resultSet = session.execute(selectTotalV2Statement.bind(UUID.fromString(workflowId), corelId));
-        Row row = resultSet.one();
-        if (row == null && fallbackToOldWorkflowExecutionTables) {
+        ResultSet resultSet;
+        if (fallbackToOldWorkflowExecutionTables) {
             resultSet = session.execute(selectTotalStatement.bind(UUID.fromString(workflowId), corelId));
-            row = resultSet.one();
+        } else {
+            resultSet = session.execute(selectTotalV2Statement.bind(UUID.fromString(workflowId), corelId));
         }
+
         recordCassandraDaoRequests("getWorkflowMetadata");
 
-        return Optional.ofNullable(row)
+        return Optional.ofNullable(resultSet.one())
                 .map(
                         currentRow -> {
                             WorkflowMetadata workflowMetadata = new WorkflowMetadata();
@@ -1390,13 +1422,13 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     String lookupWorkflowIdFromTaskId(String taskId) {
         UUID taskUUID = toUUID(taskId, "Invalid task id");
         try {
-            ResultSet resultSet = session.execute(selectTaskLookupV2Statement.bind(taskUUID));
-            Row row = resultSet.one();
-            if (row == null && fallbackToOldWorkflowExecutionTables) {
+            ResultSet resultSet;
+            if (fallbackToOldWorkflowExecutionTables) {
                 resultSet = session.execute(selectTaskLookupStatement.bind(taskUUID));
-                row = resultSet.one();
+            } else {
+                resultSet = session.execute(selectTaskLookupV2Statement.bind(taskUUID));;
             }
-            return Optional.ofNullable(row)
+            return Optional.ofNullable(resultSet.one())
                     .map(r -> r.getUUID(WORKFLOW_ID_KEY).toString())
                     .orElse(null);
         } catch (DriverException e) {
@@ -1415,13 +1447,13 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     String lookupShardIdFromTaskId(String taskId) {
         UUID taskUUID = toUUID(taskId, "Invalid task id");
         try {
-            ResultSet resultSet = session.execute(selectShardFromTaskLookupV2Statement.bind(taskUUID));
-            Row row = resultSet.one();
-            if (row == null && fallbackToOldWorkflowExecutionTables) {
-                resultSet = session.execute(selectShardFromTaskLookupStatement.bind(taskUUID));
-                row = resultSet.one();
+            ResultSet resultSet;
+            if (fallbackToOldWorkflowExecutionTables) {
+                resultSet = session.execute(selectShardFromTaskLookupStatement.bind(taskUUID));;
+            } else {
+                resultSet = session.execute(selectShardFromTaskLookupV2Statement.bind(taskUUID));
             }
-            return Optional.ofNullable(row)
+            return Optional.ofNullable(resultSet.one())
                     .map(r -> String.valueOf(r.getInt(SHARD_ID_KEY)))
                     .orElse(null);
         } catch (DriverException e) {
@@ -1440,13 +1472,13 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     String lookupShardIdFromWorkflowId(String workflowId) {
         UUID workflowUUID = toUUID(workflowId, "Invalid workflow id");
         try {
-            ResultSet resultSet = session.execute(selectShardFromWorkflowLookupV2Statement.bind(workflowUUID));
-            Row row = resultSet.one();
-            if (row == null && fallbackToOldWorkflowExecutionTables) {
+            ResultSet resultSet;
+            if (fallbackToOldWorkflowExecutionTables) {
                 resultSet = session.execute(selectShardFromWorkflowLookupStatement.bind(workflowUUID));
-                row = resultSet.one();
+            } else {
+                resultSet = session.execute(selectShardFromWorkflowLookupV2Statement.bind(workflowUUID));
             }
-            return Optional.ofNullable(row)
+            return Optional.ofNullable(resultSet.one())
                     .map(r -> String.valueOf(r.getInt(SHARD_ID_KEY)))
                     .orElse(null);
         } catch (DriverException e) {
@@ -1476,9 +1508,9 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
 
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-        this.redisLock = (RedisLock) applicationContext.getBean("provideRedisLock");
+        this.redisLock = applicationContext.getBean("provideRedisLock", RedisLock.class);
         setConcurrencyLimitEnabled(Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("concurrencyLimitEnabled", "false")));
         setFallbackToOldTaskInProgressActive(Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("fallbackToOldTaskInProgressActive", "false")));
-        this.fallbackToOldWorkflowExecutionTables = Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("fallbackToOldWorkflowExecutionTables", "false"));
+        this.fallbackToOldWorkflowExecutionTables = Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("fallbackToOldWorkflowExecutionTables", "true"));
     }
 }

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
@@ -372,12 +372,6 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
                             task.setScheduledTime(System.currentTimeMillis());
                         }
                         BatchStatement batchStatement = new BatchStatement(BatchStatement.Type.UNLOGGED);
-                        if (fallbackToOldWorkflowExecutionTables) {
-                            batchStatement.add(updateTaskLookupStatement.bind(
-                                    workflowUUID, correlationId, toUUID(task.getTaskId(), "Invalid task id")));
-                            batchStatement.add(updateWorkflowLookupStatement.bind(
-                                    correlationId, workflowUUID));
-                        }
                         batchStatement.add(updateTaskLookupV2Statement.bind(
                                 workflowUUID, correlationId, toUUID(task.getTaskId(), "Invalid task id")));
                         batchStatement.add(updateWorkflowLookupV2Statement.bind(
@@ -392,14 +386,6 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
             tasks.forEach(
                     task -> {
                         String taskPayload = toJson(task);
-                        if (fallbackToOldWorkflowExecutionTables) {
-                            batchStatement.add(
-                                    insertTaskStatement.bind(
-                                            workflowUUID,
-                                            correlationId,
-                                            task.getTaskId(),
-                                            taskPayload));
-                        }
                         batchStatement.add(
                                 insertTaskV2Statement.bind(
                                         workflowUUID,
@@ -542,14 +528,6 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
                         prevTask.getStatus());
 
                 if (!prevTask.getStatus().equals(TaskModel.Status.COMPLETED)) {**/
-                if (fallbackToOldWorkflowExecutionTables) {
-                    session.execute(
-                            insertTaskStatement.bind(
-                                    UUID.fromString(task.getWorkflowInstanceId()),
-                                    correlationId,
-                                    task.getTaskId(),
-                                    taskPayload));
-                }
                 session.execute(
                         insertTaskV2Statement.bind(
                                 UUID.fromString(task.getWorkflowInstanceId()),
@@ -764,11 +742,6 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
             recordCassandraDaoRequests("createWorkflow", "n/a", workflow.getWorkflowName());
             recordCassandraDaoPayloadSize(
                     "createWorkflow", payload.length(), "n/a", workflow.getWorkflowName());
-            if (fallbackToOldWorkflowExecutionTables) {
-                session.execute(
-                        insertWorkflowStatement.bind(
-                                UUID.fromString(workflow.getWorkflowId()), correlationId, "", payload, 0, 1, 1));
-            }
             session.execute(
                     insertWorkflowV2Statement.bind(
                             UUID.fromString(workflow.getWorkflowId()), correlationId, "", payload, 0, 1, 1));
@@ -827,7 +800,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
                 UUID.fromString(workflow.getWorkflowId()), correlationId, currentVersion));
 
         boolean wasWorkflowUpdateApplied =
-                fallbackToOldWorkflowExecutionTables ? oldTableResultSet.wasApplied() : v2ResultSet.wasApplied();
+                fallbackToOldWorkflowExecutionTables ? (oldTableResultSet.wasApplied() || v2ResultSet.wasApplied()) : v2ResultSet.wasApplied();
         if (wasWorkflowUpdateApplied) {
             LOGGER.debug("Updated workflow with isRetry {} - current status {} for workflowId {} with version {}",
                     isRetry, workflow.getStatus(), workflow.getWorkflowId(), prevWorkflow.getVersion() + 1);
@@ -861,9 +834,15 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
     @Override
     public boolean removeWorkflow(String workflowId) {
         WorkflowModel workflow = getWorkflow(workflowId, true);
+        return removeWorkflow(workflow);
+    }
+
+    @Override
+    public boolean removeWorkflow(WorkflowModel workflow) {
         Integer correlationId = Objects.isNull(workflow.getCorrelationId()) ? 0 : Integer.parseInt(workflow.getCorrelationId());
         boolean removed = false;
         if (workflow != null) {
+            String workflowId = workflow.getWorkflowId();
             try {
                 recordCassandraDaoRequests("removeWorkflow", "n/a", workflow.getWorkflowName());
                 ResultSet oldTableResultSet = null;
@@ -876,7 +855,7 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
                         session.execute(
                                 deleteWorkflowV2Statement.bind(
                                         UUID.fromString(workflowId), correlationId));
-                removed = fallbackToOldWorkflowExecutionTables ? oldTableResultSet.wasApplied() : v2ResultSet.wasApplied();
+                removed = fallbackToOldWorkflowExecutionTables ? (oldTableResultSet.wasApplied() || v2ResultSet.wasApplied()) : v2ResultSet.wasApplied();
             } catch (DriverException e) {
                 Monitors.error(CLASS_NAME, "removeWorkflow");
                 logErrorToDebug(Thread.currentThread().getStackTrace()[2].getMethodName(), e);
@@ -1465,6 +1444,6 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         this.redisLock = (RedisLock) applicationContext.getBean("provideRedisLock");
         setConcurrencyLimitEnabled(Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("concurrencyLimitEnabled", "false")));
         setFallbackToOldTaskInProgressActive(Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("fallbackToOldTaskInProgressActive", "false")));
-        this.fallbackToOldWorkflowExecutionTables = Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("fallbackToOldWorkflowExecutionTables", "false"));
+        this.fallbackToOldWorkflowExecutionTables = Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("fallbackToOldWorkflowExecutionTables", "true"));
     }
 }

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/dao/ScyllaExecutionDAO.java
@@ -845,16 +845,29 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
             String workflowId = workflow.getWorkflowId();
             try {
                 recordCassandraDaoRequests("removeWorkflow", "n/a", workflow.getWorkflowName());
+
+                // updateWorkflow uses LWT (IF version=?), which assigns a server-side Paxos
+                // timestamp that can be ahead of the client clock. A regular DELETE's
+                // client-assigned timestamp may be lower, causing the LWT-written workflow
+                // row to survive the tombstone. Query the actual write timestamp and ensure
+                // the DELETE uses a strictly higher one.
+                long lwtWriteTimestamp = queryWorkflowEntityWriteTimestamp(workflowId, correlationId);
+                long deleteTimestamp = Math.max(
+                        lwtWriteTimestamp + 1,
+                        System.currentTimeMillis() * 1000);
+
                 ResultSet oldTableResultSet = null;
                 if (fallbackToOldWorkflowExecutionTables) {
                     oldTableResultSet = session.execute(
                             deleteWorkflowStatement.bind(
-                                    UUID.fromString(workflowId), correlationId));
+                                    UUID.fromString(workflowId), correlationId)
+                                    .setDefaultTimestamp(deleteTimestamp));
                 }
                 ResultSet v2ResultSet =
                         session.execute(
                                 deleteWorkflowV2Statement.bind(
-                                        UUID.fromString(workflowId), correlationId));
+                                        UUID.fromString(workflowId), correlationId)
+                                        .setDefaultTimestamp(deleteTimestamp));
                 removed = fallbackToOldWorkflowExecutionTables ? (oldTableResultSet.wasApplied() || v2ResultSet.wasApplied()) : v2ResultSet.wasApplied();
             } catch (DriverException e) {
                 Monitors.error(CLASS_NAME, "removeWorkflow");
@@ -866,6 +879,28 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
             workflow.getTasks().forEach(this::removeTaskLookup);
         }
         return removed;
+    }
+
+    /**
+     * Queries the WRITETIME of the workflow entity row in workflows_v2.
+     * Used to determine the Paxos-assigned timestamp from LWT updates so that
+     * subsequent deletes can use a strictly higher timestamp.
+     *
+     * @return the write timestamp in microseconds, or 0 if the row does not exist
+     */
+    private long queryWorkflowEntityWriteTimestamp(String workflowId, int correlationId) {
+        try {
+            String cql = String.format(
+                    "SELECT WRITETIME(payload) AS wt FROM %s.workflows_v2 "
+                    + "WHERE workflow_id=%s AND shard_id=%d AND entity='workflow' AND task_id=''",
+                    properties.getKeyspace(), workflowId, correlationId);
+            ResultSet rs = session.execute(cql);
+            Row row = rs.one();
+            return (row != null) ? row.getLong("wt") : 0;
+        } catch (Exception e) {
+            LOGGER.warn("Failed to query workflow entity write timestamp for {}", workflowId, e);
+            return 0;
+        }
     }
 
     /**
@@ -1444,6 +1479,6 @@ public class ScyllaExecutionDAO extends ScyllaBaseDAO
         this.redisLock = (RedisLock) applicationContext.getBean("provideRedisLock");
         setConcurrencyLimitEnabled(Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("concurrencyLimitEnabled", "false")));
         setFallbackToOldTaskInProgressActive(Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("fallbackToOldTaskInProgressActive", "false")));
-        this.fallbackToOldWorkflowExecutionTables = Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("fallbackToOldWorkflowExecutionTables", "true"));
+        this.fallbackToOldWorkflowExecutionTables = Boolean.parseBoolean(applicationContext.getEnvironment().getProperty("fallbackToOldWorkflowExecutionTables", "false"));
     }
 }

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/util/Constants.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/util/Constants.java
@@ -17,8 +17,11 @@ public interface Constants {
     String DAO_NAME = "scylla";
 
     String TABLE_WORKFLOWS = "workflows";
+    String TABLE_WORKFLOWS_V2 = "workflows_v2";
     String TABLE_TASK_LOOKUP = "task_lookup";
+    String TABLE_TASK_LOOKUP_V2 = "task_lookup_v2";
     String TABLE_WORKFLOW_LOOKUP = "workflow_lookup";
+    String TABLE_WORKFLOW_LOOKUP_V2 = "workflow_lookup_v2";
     String TABLE_TASK_DEF_LIMIT = "task_def_limit";
     String TABLE_WORKFLOW_DEFS = "workflow_definitions";
     String TABLE_WORKFLOW_DEFS_INDEX = "workflow_defs_index";

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/util/Constants.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/util/Constants.java
@@ -60,6 +60,8 @@ public interface Constants {
     String ENTITY_TYPE_WORKFLOW = "workflow";
     String ENTITY_TYPE_TASK = "task";
 
+    String FUNC_WRITETIME = "writetime";
+
     int DEFAULT_SHARD_ID = 1;
     int DEFAULT_TOTAL_PARTITIONS = 1;
 }

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/util/Statements.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/util/Statements.java
@@ -513,6 +513,21 @@ public class Statements {
     }
 
     /**
+     * @return cql query statement to retrieve the WRITETIME of the workflow entity payload
+     *     from the "workflows_v2" table
+     */
+    public String getSelectWorkflowWritetimeV2Statement() {
+        return QueryBuilder.select()
+                .fcall(FUNC_WRITETIME, QueryBuilder.column(PAYLOAD_KEY)).as("wt")
+                .from(keyspace, TABLE_WORKFLOWS_V2)
+                .where(eq(WORKFLOW_ID_KEY, bindMarker()))
+                .and(eq(SHARD_ID_KEY, bindMarker()))
+                .and(eq(ENTITY_KEY, ENTITY_TYPE_WORKFLOW))
+                .and(eq(TASK_ID_KEY, ""))
+                .getQueryString();
+    }
+
+    /**
      * @return cql query statement to retrieve a workflow with its tasks from the "workflows_v2" table
      */
     public String getSelectWorkflowWithTasksV2Statement() {

--- a/scylla-persistence/src/main/java/com/netflix/conductor/scylla/util/Statements.java
+++ b/scylla-persistence/src/main/java/com/netflix/conductor/scylla/util/Statements.java
@@ -294,6 +294,35 @@ public class Statements {
                 .value(PAYLOAD_KEY, bindMarker())
                 .getQueryString();
     }
+
+    /**
+     * @return cql query statement to insert a new workflow into the "workflows_v2" table
+     */
+    public String getInsertWorkflowV2Statement() {
+        return QueryBuilder.insertInto(keyspace, TABLE_WORKFLOWS_V2)
+                .value(WORKFLOW_ID_KEY, bindMarker())
+                .value(SHARD_ID_KEY, bindMarker())
+                .value(TASK_ID_KEY, bindMarker())
+                .value(ENTITY_KEY, ENTITY_TYPE_WORKFLOW)
+                .value(PAYLOAD_KEY, bindMarker())
+                .value(TOTAL_TASKS_KEY, bindMarker())
+                .value(TOTAL_PARTITIONS_KEY, bindMarker())
+                .value(VERSION, bindMarker())
+                .getQueryString();
+    }
+
+    /**
+     * @return cql query statement to insert a new task into the "workflows_v2" table
+     */
+    public String getInsertTaskV2Statement() {
+        return QueryBuilder.insertInto(keyspace, TABLE_WORKFLOWS_V2)
+                .value(WORKFLOW_ID_KEY, bindMarker())
+                .value(SHARD_ID_KEY, bindMarker())
+                .value(TASK_ID_KEY, bindMarker())
+                .value(ENTITY_KEY, ENTITY_TYPE_TASK)
+                .value(PAYLOAD_KEY, bindMarker())
+                .getQueryString();
+    }
     /**
      * @return cql query statement to insert a new event execution into the "event_executions" table
      */
@@ -316,6 +345,19 @@ public class Statements {
     public String getSelectWorkflowsByCorrelationIdStatement() {
         return QueryBuilder.select(PAYLOAD_KEY)
                 .from(keyspace, TABLE_WORKFLOWS)
+                .where(eq(SHARD_ID_KEY, bindMarker()))
+                .and(eq(ENTITY_KEY, ENTITY_TYPE_WORKFLOW))
+                .allowFiltering()
+                .getQueryString();
+    }
+
+    /**
+     * @return cql query statement to retrieve all workflows executions from the "workflows_v2"
+     *     table by coorelationId
+     */
+    public String getSelectWorkflowsByCorrelationIdV2Statement() {
+        return QueryBuilder.select(PAYLOAD_KEY)
+                .from(keyspace, TABLE_WORKFLOWS_V2)
                 .where(eq(SHARD_ID_KEY, bindMarker()))
                 .and(eq(ENTITY_KEY, ENTITY_TYPE_WORKFLOW))
                 .allowFiltering()
@@ -433,6 +475,56 @@ public class Statements {
     }
 
     /**
+     * @return cql query statement to retrieve the total_tasks and total_partitions for a workflow
+     *     from the "workflows" table
+     */
+    public String getSelectTotalV2Statement() {
+        return QueryBuilder.select(TOTAL_TASKS_KEY, TOTAL_PARTITIONS_KEY)
+                .from(keyspace, TABLE_WORKFLOWS_V2)
+                .where(eq(WORKFLOW_ID_KEY, bindMarker()))
+                .and(eq(SHARD_ID_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    /**
+     * @return cql query statement to retrieve a task from the "workflows" table
+     */
+    public String getSelectTaskV2Statement() {
+        return QueryBuilder.select(PAYLOAD_KEY)
+                .from(keyspace, TABLE_WORKFLOWS_V2)
+                .where(eq(WORKFLOW_ID_KEY, bindMarker()))
+                .and(eq(SHARD_ID_KEY, bindMarker()))
+                .and(eq(ENTITY_KEY, ENTITY_TYPE_TASK))
+                .and(eq(TASK_ID_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    /**
+     * @return cql query statement to retrieve a workflow (without its tasks) from the "workflows_v2"
+     *     table
+     */
+    public String getSelectWorkflowV2Statement() {
+        return QueryBuilder.select(PAYLOAD_KEY,VERSION)
+                .from(keyspace, TABLE_WORKFLOWS_V2)
+                .where(eq(WORKFLOW_ID_KEY, bindMarker()))
+                .and(eq(SHARD_ID_KEY, bindMarker()))
+                .and(eq(ENTITY_KEY, ENTITY_TYPE_WORKFLOW))
+                .getQueryString();
+    }
+
+    /**
+     * @return cql query statement to retrieve a workflow with its tasks from the "workflows_v2" table
+     */
+    public String getSelectWorkflowWithTasksV2Statement() {
+        return QueryBuilder.select()
+                .all()
+                .from(keyspace, TABLE_WORKFLOWS_V2)
+                .where(eq(WORKFLOW_ID_KEY, bindMarker()))
+                .and(eq(SHARD_ID_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    /**
      * @return cql query statement to retrieve the workflow_id for a particular task_id from the
      *     "task_lookup" table
      */
@@ -455,12 +547,45 @@ public class Statements {
     }
 
     /**
+     * @return cql query statement to retrieve the workflow_id for a particular task_id from the
+     *     "task_lookup_v2" table
+     */
+    public String getSelectTaskFromLookupTableV2Statement() {
+        return QueryBuilder.select(WORKFLOW_ID_KEY)
+                .from(keyspace, TABLE_TASK_LOOKUP_V2)
+                .where(eq(TASK_ID_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    /**
+     * @return cql query statement to retrieve the shard_id for a particular task_id from the
+     *     "task_lookup_v2" table
+     */
+    public String getSelectShardFromTaskLookupTableV2Statement() {
+        return QueryBuilder.select(SHARD_ID_KEY)
+                .from(keyspace, TABLE_TASK_LOOKUP_V2)
+                .where(eq(TASK_ID_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    /**
      * @return cql query statement to retrieve the shard_id for a particular workflow_id  from the
      *     "workflow_lookup" table
      */
     public String getSelectShardFromWorkflowLookupTableStatement() {
         return QueryBuilder.select(SHARD_ID_KEY)
                 .from(keyspace, TABLE_WORKFLOW_LOOKUP)
+                .where(eq(WORKFLOW_ID_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    /**
+     * @return cql query statement to retrieve the shard_id for a particular workflow_id  from the
+     *     "workflow_lookup_v2" table
+     */
+    public String getSelectShardFromWorkflowLookupTableV2Statement() {
+        return QueryBuilder.select(SHARD_ID_KEY)
+                .from(keyspace, TABLE_WORKFLOW_LOOKUP_V2)
                 .where(eq(WORKFLOW_ID_KEY, bindMarker()))
                 .getQueryString();
     }
@@ -533,6 +658,46 @@ public class Statements {
     }
 
     /**
+     * @return cql query statement to update a workflow in the "workflows_v2" table
+     */
+    public String getUpdateWorkflowV2Statement() {
+        return QueryBuilder.update(keyspace, TABLE_WORKFLOWS_V2)
+                .with(set(PAYLOAD_KEY, bindMarker()))
+                .and(set(VERSION, bindMarker()))
+                .where(eq(WORKFLOW_ID_KEY, bindMarker()))
+                .and(eq(SHARD_ID_KEY, bindMarker()))
+                .and(eq(ENTITY_KEY, ENTITY_TYPE_WORKFLOW))
+                .and(eq(TASK_ID_KEY, ""))
+                .onlyIf(eq(VERSION, bindMarker()))
+                .getQueryString();
+    }
+
+    /**
+     * @return cql query statement to update the total_tasks in a shard for a workflow in the
+     *     "workflows_v2" table
+     */
+    public String getUpdateTotalTasksV2Statement() {
+        return QueryBuilder.update(keyspace, TABLE_WORKFLOWS_V2)
+                .with(set(TOTAL_TASKS_KEY, bindMarker()))
+                .where(eq(WORKFLOW_ID_KEY, bindMarker()))
+                .and(eq(SHARD_ID_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    /**
+     * @return cql query statement to update the total_partitions for a workflow in the "workflows_v2"
+     *     table
+     */
+    public String getUpdateTotalPartitionsV2Statement() {
+        return QueryBuilder.update(keyspace, TABLE_WORKFLOWS_V2)
+                .with(set(TOTAL_PARTITIONS_KEY, bindMarker()))
+                .and(set(TOTAL_TASKS_KEY, bindMarker()))
+                .where(eq(WORKFLOW_ID_KEY, bindMarker()))
+                .and(eq(SHARD_ID_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    /**
      * @return cql query statement to add a new task_id to workflow_id mapping to the "task_lookup"
      *     table
      */
@@ -545,11 +710,34 @@ public class Statements {
     }
 
     /**
+     * @return cql query statement to add a new task_id to workflow_id mapping to the "task_lookup_v2"
+     *     table
+     */
+    public String getUpdateTaskLookupV2Statement() {
+        return QueryBuilder.update(keyspace, TABLE_TASK_LOOKUP_V2)
+                .with(set(WORKFLOW_ID_KEY, bindMarker()))
+                .and(set(SHARD_ID_KEY, bindMarker()))
+                .where(eq(TASK_ID_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    /**
      * @return cql query statement to update shard_id to workflow_id mapping to the "workflow_lookup"
      *     table
      */
     public String getUpdateWorkflowLookupStatement() {
         return QueryBuilder.update(keyspace, TABLE_WORKFLOW_LOOKUP)
+                .with(set(SHARD_ID_KEY, bindMarker()))
+                .where(eq(WORKFLOW_ID_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    /**
+     * @return cql query statement to update shard_id to workflow_id mapping to the "workflow_lookup_v2"
+     *     table
+     */
+    public String getUpdateWorkflowLookupV2Statement() {
+        return QueryBuilder.update(keyspace, TABLE_WORKFLOW_LOOKUP_V2)
                 .with(set(SHARD_ID_KEY, bindMarker()))
                 .where(eq(WORKFLOW_ID_KEY, bindMarker()))
                 .getQueryString();
@@ -593,12 +781,34 @@ public class Statements {
     }
 
     /**
+     * @return cql query statement to delete a workflow from the "workflows_v2" table
+     */
+    public String getDeleteWorkflowV2Statement() {
+        return QueryBuilder.delete()
+                .from(keyspace, TABLE_WORKFLOWS_V2)
+                .where(eq(WORKFLOW_ID_KEY, bindMarker()))
+                .and(eq(SHARD_ID_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    /**
      * @return cql query statement to delete a task_id to workflow_id mapping from the "task_lookup"
      *     table
      */
     public String getDeleteTaskLookupStatement() {
         return QueryBuilder.delete()
                 .from(keyspace, TABLE_TASK_LOOKUP)
+                .where(eq(TASK_ID_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    /**
+     * @return cql query statement to delete a task_id to workflow_id mapping from the "task_lookup_v2"
+     *     table
+     */
+    public String getDeleteTaskLookupV2Statement() {
+        return QueryBuilder.delete()
+                .from(keyspace, TABLE_TASK_LOOKUP_V2)
                 .where(eq(TASK_ID_KEY, bindMarker()))
                 .getQueryString();
     }
@@ -615,11 +825,35 @@ public class Statements {
     }
 
     /**
+     * @return cql query statement to delete a workflow_lookup entry from the "workflow_lookup"
+     *     table
+     */
+    public String getDeleteWorkflowLookupV2Statement() {
+        return QueryBuilder.delete()
+                .from(keyspace, TABLE_WORKFLOW_LOOKUP_V2)
+                .where(eq(WORKFLOW_ID_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    /**
      * @return cql query statement to delete a task from the "workflows" table
      */
     public String getDeleteTaskStatement() {
         return QueryBuilder.delete()
                 .from(keyspace, TABLE_WORKFLOWS)
+                .where(eq(WORKFLOW_ID_KEY, bindMarker()))
+                .and(eq(SHARD_ID_KEY, bindMarker()))
+                .and(eq(ENTITY_KEY, ENTITY_TYPE_TASK))
+                .and(eq(TASK_ID_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    /**
+     * @return cql query statement to delete a task from the "workflows_v2" table
+     */
+    public String getDeleteTaskV2Statement() {
+        return QueryBuilder.delete()
+                .from(keyspace, TABLE_WORKFLOWS_V2)
                 .where(eq(WORKFLOW_ID_KEY, bindMarker()))
                 .and(eq(SHARD_ID_KEY, bindMarker()))
                 .and(eq(ENTITY_KEY, ENTITY_TYPE_TASK))


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR

Workflow execution tables have 7 days TTL. Extended the TTL with another table without TTL. Handled deletion on workflow completion instead of TTL. Handled dual writes and reads with feature flag which will be removed eventually.

TODO: Tables creations and environment variable addition for feature flag.

Issue #

As part of legacy workflow parity, we need to support 60 days or more for timer nodes (tasks). So TTL of 7 days will make the workflow records get cleared.

https://freshworks.freshrelease.com/ws/FS/tasks/FS-350048

Alternatives considered
----
Approaches:
https://confluence.freshworks.com/pages/viewpage.action?pageId=587766653&spaceKey=FRES&title=Analysis%2Bon%2Bincreasing%2BTTL%2Bfor%2Bconductor%2Btables
